### PR TITLE
Fix libpsl-native to build and pass tests on FreeBSD

### DIFF
--- a/src/libpsl-native/src/getuserfrompid.cpp
+++ b/src/libpsl-native/src/getuserfrompid.cpp
@@ -15,6 +15,10 @@
 #include <sys/sysctl.h>
 #endif
 
+#if __FreeBSD__
+#include <sys/user.h>
+#endif
+
 char* GetUserFromPid(pid_t pid)
 {
 
@@ -44,6 +48,22 @@ char* GetUserFromPid(pid_t pid)
     }
 
     return GetPwUid(oldp.kp_eproc.e_ucred.cr_uid);
+
+#elif defined(__FreeBSD__)
+
+    // Get effective owner of pid from sysctl
+    struct kinfo_proc oldp;
+    size_t oldlenp = sizeof(oldp);
+    int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
+    u_int namelen = sizeof(name)/sizeof(int);
+
+    int ret = sysctl(name, namelen, &oldp, &oldlenp, NULL, 0);
+    if (ret != 0 || oldlenp == 0)
+    {
+        return NULL;
+    }
+
+    return GetPwUid(oldp.ki_uid);
 
 #else
 


### PR DESCRIPTION
Moving this PR from [PowerShell/#7208](https://github.com/PowerShell/PowerShell/pull/7208) as requested by @adityapatwardhan 

The only change necessary after all was in file `getuserfrompid.cpp`, since `isfile.cpp` is following a PathExists implementation and was correct in the first place as tests were previously fixed.

With changes from this PR, all tests are passing on FreeBSD.