### PR TITLE
Enable VSTS CI for PowerShell-Native repository

### DIFF
--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -1,0 +1,30 @@
+name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  # Enable VSTS debug mode until stabilitized
+  system.debug: 'true'
+
+resources:
+  - repo: self
+    clean: true
+phases:
+- phase: Build
+
+  queue:
+    name: Hosted Ubuntu 1604
+    parallel: 2
+    matrix:
+      Linux ARM Native:
+        buildName: ubuntu.16.04
+      Linux Native:
+        buildName: centos.7
+
+  steps:
+  - powershell: |
+      tools/releaseBuild/vstsBuild.ps1 -Name $(buildName) -Verbose
+    displayName: Start build - $(buildName)
+    condition: succeededOrFailed()

--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -5,8 +5,6 @@ variables:
   POWERSHELL_TELEMETRY_OPTOUT: 1
   # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  # Enable VSTS debug mode until stabilitized
-  system.debug: 'true'
 
 resources:
   - repo: self

--- a/.vsts-ci/mac.yml
+++ b/.vsts-ci/mac.yml
@@ -1,0 +1,24 @@
+name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+resources:
+  - repo: self
+    clean: true
+phases:
+- phase: Build
+
+  queue:
+    name: Hosted macOS
+  steps:
+  - powershell: |
+      tools/releaseBuild/PowershellNative.ps1 -Arch osx -Configuration Release -RepoRoot $(Build.SourcesDirectory) -TargetLocation "$(System.ArtifactsDirectory)/Packages" -Verbose
+      Write-Host "##vso[artifact.upload containerfolder=artifacts;artifactname=artifacts]$(System.ArtifactsDirectory)/Packages/osx-symbols.zip"
+      $testResultPath = Get-ChildItem -Recurse -Filter 'native-tests.xml'
+      if($testResultPath -and (Test-Path $testResultPath)) { Write-Host "##vso[results.publish type=JUnit;mergeResults=true;runTitle=Native Test Results OSX;publishRunAttachments=true;resultFiles=$testResultPath;]"}
+    displayName: Start build
+    condition: succeededOrFailed()

--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -1,0 +1,51 @@
+name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+resources:
+  - repo: self
+    clean: true
+phases:
+- phase: Build
+
+  queue:
+    name: Hosted Windows Container
+    parallel: 4
+    matrix:
+      Windows x86:
+        buildName: x86
+      Windows x64:
+        buildName: x64
+      Windows x64_arm:
+        buildName: x64_arm
+      Windows x64_arm64:
+        buildName: x64_arm64
+
+  steps:
+  - powershell: |
+      choco install cmake.install --installargs 'ADD_CMAKE_TO_PATH=System'
+    displayName: Install cmake
+    condition: succeededOrFailed()
+  - powershell: |
+      choco install windows-sdk-10.1
+    displayName: Install Windows SDK 10.1
+    condition: succeeded()
+  - powershell: |
+      Invoke-WebRequest "https://aka.ms/vs/15/release/vs_BuildTools.exe" -OutFile vs_BuildTools.exe -UseBasicParsing
+      Start-Process -FilePath 'vs_BuildTools.exe' -ArgumentList '--quiet', '--norestart', '--locale en-US', '--add Microsoft.VisualStudio.Component.VC.Tools.ARM', '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64', '--includeRecommended', '--add Microsoft.VisualStudio.Workload.VCTools', '--add Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop.arm', '--add Microsoft.VisualStudio.Component.VC.ATL', '--add Microsoft.VisualStudio.Component.VC.ATLMFC', '--add Microsoft.VisualStudio.Component.VC.ATL.ARM', '--add Microsoft.VisualStudio.Component.VC.ATL.ARM64' -Wait
+      Remove-Item .\vs_BuildTools.exe
+      Remove-Item -Force -Recurse 'C:\Program Files (x86)\Microsoft Visual Studio\Installer'
+      setx /M PATH $($Env:PATH + ';' + ${Env:ProgramFiles(x86)} + '\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin')
+    displayName: Install Visual Studio 2017
+    condition: succeeded()
+  - powershell: |
+      $cmakeBinPath = "$env:ProgramFiles\CMake\bin\"
+      if(Test-Path $cmakeBinPath) { $env:Path = "$cmakeBinPath;$env:PATH" } else { throw "CMake not installed under $cmakeBinPath" }
+      $(Build.SourcesDirectory)\tools\releaseBuild\PowerShellNative.ps1 -RepoRoot $(Build.SourcesDirectory) -TargetLocation "$(System.ArtifactsDirectory)\Packages" -Arch $(buildName) -Configuration Release -Symbols
+      Write-Host "##vso[artifact.upload containerfolder=artifacts;artifactname=artifacts]$(System.ArtifactsDirectory)\Packages\$(buildName)-symbols.zip"
+    displayName: Start build - $(buildName)
+    condition: succeeded()

--- a/build.psm1
+++ b/build.psm1
@@ -215,13 +215,34 @@ function Start-BuildNativeWindowsBinaries {
     if ($env:VS140COMNTOOLS -ne $null) {
         $vcPath = (Get-Item(Join-Path -Path "$env:VS140COMNTOOLS" -ChildPath '../../vc')).FullName
     }
+    Write-Verbose -Verbose "VCPath: $vcPath"
 
-    $alternateVCPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017" -Filter "VC" -Directory -Recurse | Select-Object -First 1).FullName
+    $alternateVCPath = (Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017" -Filter "VC" -Directory -Recurse).FullName
+    Write-Verbose -Verbose "alternateVCPath: $alternateVCPath"
 
-    $atlMfcIncludePath = Join-Path -Path $vcPath -ChildPath 'atlmfc/include'
+    if ($vcPath) {
+        $atlMfcIncludePath = Join-Path -Path $vcPath -ChildPath 'atlmfc/include'
+        if(Test-Path -Path "$atlMfcIncludePath\atlbase.h") {
+            Write-Verbose -Verbose "ATLF MFC found under $atlMfcIncludePath\atlbase.h"
+            $atlBaseFound = $true
+        }
+    } elseif ($alternateVCPath) {
+        foreach($candidatePath in $alternateVCPath) {
+            $atlMfcIncludePath = Join-Path -Path $candidatePath -ChildPath 'atlmfc/include'
+            Write-Verbose -Verbose "Looking under $atlMfcIncludePath"
+            if(Test-Path -Path "$atlMfcIncludePath\atlbase.h") {
+                Write-Verbose -Verbose "ATLF MFC found under $atlMfcIncludePath\atlbase.h"
+                $atlBaseFound = $true
+                break
+            }
+        }
+    } else {
+        Write-Verbose -Verbose "PATH: $env:PATH"
+        throw "Visual Studio tools not found in PATH."
+    }
 
     # atlbase.h is included in the pwrshplugin project
-    if ((Test-Path -Path $atlMfcIncludePath\atlbase.h) -eq $false) {
+    if ($atlBaseFound) {
         throw "Could not find Visual Studio include file atlbase.h at $atlMfcIncludePath. Please ensure the optional feature 'Microsoft Foundation Classes for C++' is installed."
     }
 

--- a/build.psm1
+++ b/build.psm1
@@ -232,10 +232,13 @@ function Start-BuildNativeWindowsBinaries {
         foreach($candidatePath in $alternateVCPath) {
             Write-Verbose -Verbose "Looking under $candidatePath"
             $atlMfcIncludePath = Get-ChildItem -Path $candidatePath -Recurse -Filter 'atlbase.h' -File
-            if($atlMfcIncludePath.FullName.EndsWith('atlmfc\include\atlbase.h')) {
-                Write-Verbose -Verbose "ATLF MFC found under $atlMfcIncludePath\atlbase.h"
-                $atlBaseFound = $true
-                break
+
+            $atlMfcIncludePath | ForEach-Object {
+                if($$_.FullName.EndsWith('atlmfc\include\atlbase.h')) {
+                    Write-Verbose -Verbose "ATLF MFC found under $($_.FullName)"
+                    $atlBaseFound = $true
+                    break
+                }
             }
         }
     } else {

--- a/build.psm1
+++ b/build.psm1
@@ -231,10 +231,10 @@ function Start-BuildNativeWindowsBinaries {
     } elseif ($alternateVCPath) {
         foreach($candidatePath in $alternateVCPath) {
             Write-Verbose -Verbose "Looking under $candidatePath"
-            $atlMfcIncludePath = Get-ChildItem -Path $candidatePath -Recurse -Filter 'atlbase.h' -File
+            $atlMfcIncludePath = @(Get-ChildItem -Path $candidatePath -Recurse -Filter 'atlbase.h' -File)
 
             $atlMfcIncludePath | ForEach-Object {
-                if($$_.FullName.EndsWith('atlmfc\include\atlbase.h')) {
+                if($_.FullName.EndsWith('atlmfc\include\atlbase.h')) {
                     Write-Verbose -Verbose "ATLF MFC found under $($_.FullName)"
                     $atlBaseFound = $true
                     break

--- a/tools/releaseBuild/PowershellNative.ps1
+++ b/tools/releaseBuild/PowershellNative.ps1
@@ -32,11 +32,20 @@ end {
     Write-Verbose "Created output directory: $binOut" -Verbose
 
     if ($Arch -eq 'linux-x64' -or $Arch -eq 'osx') {
+
+        Write-Verbose "Starting Build for: $Arch" -Verbose
+
         Start-PSBootstrap
         Start-BuildNativeUnixBinaries
 
         $buildOutputPath = Join-Path $RepoRoot "src/powershell-unix"
         Compress-Archive -Path $buildOutputPath/libpsl-native.* -DestinationPath "$TargetLocation/$Arch-symbols.zip" -Verbose
+
+        $testResultPath = Join-Path $RepoRoot -ChildPath 'src/libpsl-native/test/native-tests.xml'
+
+        if (Test-Path $testResultPath) {
+            Copy-Item $testResultPath -Destination "$TargetLocation/linux-x64-native-tests.xml" -Verbose
+        }
     }
     elseif ($Arch -eq 'linux-arm') {
         Start-PSBootstrap -BuildLinuxArm

--- a/tools/releaseBuild/PowershellNative.ps1
+++ b/tools/releaseBuild/PowershellNative.ps1
@@ -25,7 +25,7 @@ param (
 )
 
 end {
-
+    Write-Verbose -Verbose "Starting PowerShellNative.ps1 Arch: $Arch, Config: $Configuration, Repo: $RepoRoot, Target: $TargetLocation"
     Import-Module $RepoRoot/build.psm1 -Force
     #$binOut = New-Item -Path $TargetLocation/$Arch -ItemType Directory -Force
     $binOut = New-Item -Path $TargetLocation -ItemType Directory -Force
@@ -44,7 +44,14 @@ end {
         $testResultPath = Join-Path $RepoRoot -ChildPath 'src/libpsl-native/test/native-tests.xml'
 
         if (Test-Path $testResultPath) {
-            Copy-Item $testResultPath -Destination "$TargetLocation/linux-x64-native-tests.xml" -Verbose
+            if ($Arch -eq 'linux-x64') {
+                $name = 'linux-x64-native-tests.xml'
+            }
+            else {
+                $name = 'osx-native-tests.xml'
+            }
+
+            Copy-Item $testResultPath -Destination "$TargetLocation/$name" -Verbose
         }
     }
     elseif ($Arch -eq 'linux-arm') {
@@ -55,9 +62,11 @@ end {
         Compress-Archive -Path $buildOutputPath/libpsl-native.* -DestinationPath "$TargetLocation/$Arch-symbols.zip" -Verbose
     }
     else {
+        Write-Verbose "Starting Start-PSBootstrap" -Verbose
         Start-PSBootstrap -BuildWindowsNative
+        Write-Verbose "Starting Start-BuildNativeWindowsBinaries" -Verbose
         Start-BuildNativeWindowsBinaries -Configuration $Configuration -Arch $Arch -Clean
-
+        Write-Verbose "Completed Start-BuildNativeWindowsBinaries" -Verbose
         $buildOutputPath = Join-Path $RepoRoot "src/powershell-win-core"
         Compress-Archive -Path "$buildOutputPath/*.dll" -DestinationPath "$TargetLocation/$Arch-symbols.zip" -Verbose
 

--- a/tools/releaseBuild/vstsBuild.ps1
+++ b/tools/releaseBuild/vstsBuild.ps1
@@ -75,6 +75,15 @@ end {
         Write-VstsError -Error $_
     }
     finally {
+        $testResultPath = Get-ChildItem $env:AGENT_TEMPDIRECTORY -Recurse -Filter 'linux-x64-native-tests.xml'
+
+        if($testResultPath -and (Test-Path $testResultPath)) {
+            Write-Host "##vso[results.publish type=JUnit;mergeResults=true;runTitle=Native Test Results;publishRunAttachments=true;resultFiles=$testResultPath;]"
+        }
+        else {
+            Write-Verbose -Verbose "Test results file was not found."
+        }
+
         Write-VstsTaskState
         exit 0
     }


### PR DESCRIPTION
Enable CI for the repo. The tests are executed on Linux and macOS. Artifacts are available for all the platforms. 