### PR TITLE
 Update nuspec to use license expression

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -571,6 +571,7 @@ function Start-BuildPowerShellNativePackage
             <projectUrl>https://github.com/PowerShell/PowerShell</projectUrl>
             <iconUrl>https://github.com/PowerShell/PowerShell/blob/master/assets/Powershell_black_64.png?raw=true</iconUrl>
             <licenseUrl>https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt</licenseUrl>
+            <license type="expression">MIT</license>
             <tags>PowerShell</tags>
             <language>en-US</language>
             <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/build.psm1
+++ b/build.psm1
@@ -570,7 +570,6 @@ function Start-BuildPowerShellNativePackage
         <description>Native binaries for PowerShell Core</description>
             <projectUrl>https://github.com/PowerShell/PowerShell</projectUrl>
             <iconUrl>https://github.com/PowerShell/PowerShell/blob/master/assets/Powershell_black_64.png?raw=true</iconUrl>
-            <licenseUrl>https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt</licenseUrl>
             <license type="expression">MIT</license>
             <tags>PowerShell</tags>
             <language>en-US</language>


### PR DESCRIPTION
see https://github.com/lunet-io/markdig/pull/295#issuecomment-456605310 on why the licenseUrl was removed