### PR TITLE
Add MailKit and MimeKit as trusted assemblies

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -668,6 +668,7 @@ namespace NativeMsh
     // NOTE: The names must not include the .dll extension because it will be added programmatically.
     static PCSTR trustedAssemblies[] =
     {
+        "MailKit",
         "Markdig",
         "Microsoft.ApplicationInsights",
         "Microsoft.CodeAnalysis",
@@ -692,6 +693,7 @@ namespace NativeMsh
         "Microsoft.Win32.SystemEvents",
         "Microsoft.WSMan.Management",
         "Microsoft.WSMan.Runtime",
+        "MimeKit",
         "mscorlib",
         "netstandard",
         "Newtonsoft.Json",


### PR DESCRIPTION
PR adds MailKit and MimeKit as trusted assemblies in remoting scenarios

As per comment of @TravisEz13 in PowerShell/PowerShell#10246

**Context**
PR PowerShell/PowerShell#10246 is a rework of the Send-MailMessage cmdlet which intends to use the external dependencies [MailKit and MimeKit](https://github.com/jstedfast/MailKit).
The CI in PowerShell main repo fails right now, as MailKit.dll and MimeKit.dll are not yet registered as trusted. This PR intends to fix this.

@adityapatwardhan Could you please tell me if there are any other necessary changes to the code required to make the DLLs as trusted?
Once this PR is complete, would it be possible to pre-release PowerShell-Native, and merge the updated dependency in PowerShell as suggested by @TravisEz13?