### PR TITLE
add System.Windows.Forms as trusted assembly to support clipboard

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -871,6 +871,7 @@ namespace NativeMsh
         "System.Web",
         "System.Web.HttpUtility",
         "System.Windows",
+        "System.Windows.Forms",
         "System.Xml",
         "System.Xml.Linq",
         "System.Xml.ReaderWriter",


### PR DESCRIPTION
Clipboard class requires System.Windows.Forms asseembly.  Needed for https://github.com/PowerShell/PowerShell/pull/10340