### PR TITLE
Add a number of native calls to prepare for stat in PowerShell

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -439,6 +439,19 @@ function Start-BuildNativeUnixBinaries {
 
     git clean -qfdX $Native
 
+    # the stat tests rely on stat(1). On most platforms, this is /usr/bin/stat,
+    # but on alpine it is in /bin. Be sure that /usr/bin/stat exists, or
+    # create a link from /bin/stat. If /bin/stat is missing, we'll have to fail the build
+
+    if ( ! (Test-Path /usr/bin/stat) ) {
+        if ( Test-Path /bin/stat ) {
+            New-Item -Type SymbolicLink -Path /usr/bin/stat -Target /bin/stat
+        }
+        else {
+            throw "Cannot create symlink to stat(1)"
+        }
+    }
+
     try {
         Push-Location $Native
         if ($BuildLinuxArm) {

--- a/build.psm1
+++ b/build.psm1
@@ -1927,7 +1927,7 @@ function Start-PSBootstrap {
 
             # Install ours and .NET's dependencies
             $Deps = @()
-            if ($Environment.IsUbuntu) {
+            if ($Environment.IsUbuntu -or $Environment.IsDebian) {
                 # Build tools
                 $Deps += "curl", "g++", "cmake", "make"
 

--- a/build.psm1
+++ b/build.psm1
@@ -2018,7 +2018,7 @@ function Start-PSBootstrap {
                     }
                     New-Item -Type SymbolicLink -Target $itemPath -Path $linkPath
                 }
-                
+
             } elseif ($Environment.IsMacOS) {
                 precheck 'brew' "Bootstrap dependency 'brew' not found, must install Homebrew! See http://brew.sh/"
 

--- a/src/libpsl-native/gmock.pc
+++ b/src/libpsl-native/gmock.pc
@@ -1,0 +1,9 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gmock
+Description: GoogleMock (without main() function)
+Version: 1.9.0
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgmock 
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1 

--- a/src/libpsl-native/gmock_main.pc
+++ b/src/libpsl-native/gmock_main.pc
@@ -1,0 +1,9 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gmock_main
+Description: GoogleMock (with main() function)
+Version: 1.9.0
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgmock_main 
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1 

--- a/src/libpsl-native/gtest.pc
+++ b/src/libpsl-native/gtest.pc
@@ -1,0 +1,9 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gtest
+Description: GoogleTest (without main() function)
+Version: 1.9.0
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgtest 
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1 

--- a/src/libpsl-native/gtest_main.pc
+++ b/src/libpsl-native/gtest_main.pc
@@ -1,0 +1,10 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gtest_main
+Description: GoogleTest (with main() function)
+Version: 1.9.0
+URL: https://github.com/google/googletest
+Requires: gtest
+Libs: -L${libdir} -lgtest_main 
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1 

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(psl-native SHARED
   getstat.cpp
   getcommonstat.cpp
   getpwuid.cpp
+  getgrgid.cpp
   getppid.cpp
   getuserfrompid.cpp
   getfileowner.cpp

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -2,6 +2,7 @@ include(CheckIncludeFiles)
 
 add_library(psl-native SHARED
   getstat.cpp
+  getcommonstat.cpp
   getpwuid.cpp
   getppid.cpp
   getuserfrompid.cpp

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -2,7 +2,9 @@ include(CheckIncludeFiles)
 
 add_library(psl-native SHARED
   getstat.cpp
+  getlstat.cpp
   getcommonstat.cpp
+  getcommonlstat.cpp
   getpwuid.cpp
   getgrgid.cpp
   getppid.cpp

--- a/src/libpsl-native/src/getcommonlstat.cpp
+++ b/src/libpsl-native/src/getcommonlstat.cpp
@@ -3,7 +3,6 @@
 
 //! @brief returns the stat of a file
 
-#include "getcommonstat.h"
 
 #include <errno.h>
 #include <assert.h>
@@ -15,14 +14,16 @@
 
 #include <stdio.h>
 
+#include "getcommonlstat.h"
+
 // Provide a common structure for the various different stat structures.
 // This should be safe to call on all platforms
-int GetCommonStat(const char* path, struct CommonStat* commonStat)
+int GetCommonLStat(const char* path, struct CommonStat* commonStat)
 {
     struct stat st;
     assert(path);
     errno = 0;
-    if (stat(path, &st) == 0)
+    if (lstat(path, &st) == 0)
     {
         commonStat->Inode = st.st_ino;
         commonStat->Mode = st.st_mode;

--- a/src/libpsl-native/src/getcommonlstat.cpp
+++ b/src/libpsl-native/src/getcommonlstat.cpp
@@ -3,7 +3,6 @@
 
 //! @brief returns the stat of a file
 
-
 #include <errno.h>
 #include <assert.h>
 #include <sys/types.h>

--- a/src/libpsl-native/src/getcommonlstat.cpp
+++ b/src/libpsl-native/src/getcommonlstat.cpp
@@ -34,11 +34,11 @@ int GetCommonLStat(const char* path, struct CommonStat* commonStat)
 #if defined (__APPLE__)
         commonStat->AccessTime   = st.st_atimespec.tv_sec;
         commonStat->ModifiedTime = st.st_mtimespec.tv_sec;
-        commonStat->CreationTime = st.st_ctimespec.tv_sec;
+        commonStat->ChangeTime = st.st_ctimespec.tv_sec;
 #else
         commonStat->AccessTime   = st.st_atime;
         commonStat->ModifiedTime = st.st_mtime;
-        commonStat->CreationTime = st.st_ctime;
+        commonStat->ChangeTime = st.st_ctime;
 #endif
         commonStat->BlockSize = st.st_blksize;
         commonStat->DeviceId = st.st_dev;

--- a/src/libpsl-native/src/getcommonlstat.cpp
+++ b/src/libpsl-native/src/getcommonlstat.cpp
@@ -50,6 +50,9 @@ int GetCommonLStat(const char* path, struct CommonStat* commonStat)
         commonStat->IsNamedPipe = S_ISFIFO(st.st_mode);
         commonStat->IsSocket = S_ISSOCK(st.st_mode);
         commonStat->IsSymbolicLink = S_ISLNK(st.st_mode);
+        commonStat->IsSetUid = (st.st_mode & 0xE00) == S_ISUID;
+        commonStat->IsSetGid = (st.st_mode & 0xE00) == S_ISGID;
+        commonStat->IsSticky = (st.st_mode & 0xE00) == S_ISVTX;
         return 0;
     }
     return -1;

--- a/src/libpsl-native/src/getcommonlstat.h
+++ b/src/libpsl-native/src/getcommonlstat.h
@@ -5,7 +5,6 @@
 
 #include "pal.h"
 
-
 #include <sys/stat.h>
 
 #include "getcommonstat.h"

--- a/src/libpsl-native/src/getcommonlstat.h
+++ b/src/libpsl-native/src/getcommonlstat.h
@@ -5,10 +5,14 @@
 
 #include "pal.h"
 
+
 #include <sys/stat.h>
+
+#include "getcommonstat.h"
 
 PAL_BEGIN_EXTERNC
 
-int32_t GetStat(const char* path, struct stat* buf);
+int32_t GetLStat(const char* path, struct stat* buf);
+int GetCommonLStat(const char* path, CommonStat* cs);
 
 PAL_END_EXTERNC

--- a/src/libpsl-native/src/getcommonlstat.h
+++ b/src/libpsl-native/src/getcommonlstat.h
@@ -16,3 +16,4 @@ int32_t GetLStat(const char* path, struct stat* buf);
 int GetCommonLStat(const char* path, CommonStat* cs);
 
 PAL_END_EXTERNC
+

--- a/src/libpsl-native/src/getcommonstat.cpp
+++ b/src/libpsl-native/src/getcommonstat.cpp
@@ -13,25 +13,71 @@
 #include <string.h>
 #include <unistd.h>
 
-// Provide a common structure for the various different stat structures
-int GetCommonStat(const char* path, struct CommonStat* commonStat)
+#include <stdio.h>
+
+// Provide a common structure for the various different stat structures.
+// This should be safe to call on all platforms
+int GetCommonLStat(const char* path, struct CommonStat* commonStat)
 {
     struct stat st;
-    struct CommonStat cs;
-    if (GetStat(path, &st) == 0)
+    assert(path);
+    errno = 0;
+    if (lstat(path, &st) == 0)
     {
-        cs.Inode = st.st_ino;
-        cs.IsDirectory = S_ISDIR(st.st_mode);
-        cs.IsFile = S_ISREG(st.st_mode);
-        cs.IsBlockDevice = S_ISBLK(st.st_mode);
-        cs.IsCharacterDevice = S_ISCHR(st.st_mode);
-        cs.IsNamedPipe = S_ISFIFO(st.st_mode);
-        cs.IsSocket = S_ISSOCK(st.st_mode);
-        cs.Mode = st.st_mode;
-        cs.UserId = st.st_uid;
-        cs.GroupId = st.st_gid;
-        commonStat = &cs;
+        commonStat->Inode = st.st_ino;
+        commonStat->Mode = st.st_mode;
+        commonStat->UserId = st.st_uid;
+        commonStat->GroupId = st.st_gid;
+        commonStat->HardlinkCount = st.st_nlink;
+        commonStat->Size = st.st_size;
+        commonStat->AccessTime = st.st_atimespec.tv_sec;
+        commonStat->ModifiedTime = st.st_mtimespec.tv_sec;
+        commonStat->CreationTime = st.st_ctimespec.tv_sec;
+        commonStat->BlockSize = st.st_blksize;
+        commonStat->DeviceId = st.st_dev;
+        commonStat->NumberOfBlocks = st.st_blocks;
+        commonStat->IsBlockDevice = S_ISBLK(st.st_mode);
+        commonStat->IsCharacterDevice = S_ISCHR(st.st_mode);
+        commonStat->IsDirectory = S_ISDIR(st.st_mode);
+        commonStat->IsFile = S_ISREG(st.st_mode);
+        commonStat->IsNamedPipe = S_ISFIFO(st.st_mode);
+        commonStat->IsSocket = S_ISSOCK(st.st_mode);
+        commonStat->IsSymbolicLink = S_ISLNK(st.st_mode);
         return 0;
     }
     return -1;
 }
+
+// Provide a common structure for the various different stat structures.
+// This should be safe to call on all platforms
+int GetCommonStat(const char* path, struct CommonStat* commonStat)
+{
+    struct stat st;
+    assert(path);
+    errno = 0;
+    if (stat(path, &st) == 0)
+    {
+        commonStat->Inode = st.st_ino;
+        commonStat->Mode = st.st_mode;
+        commonStat->UserId = st.st_uid;
+        commonStat->GroupId = st.st_gid;
+        commonStat->HardlinkCount = st.st_nlink;
+        commonStat->Size = st.st_size;
+        commonStat->AccessTime = st.st_atimespec.tv_sec;
+        commonStat->ModifiedTime = st.st_mtimespec.tv_sec;
+        commonStat->CreationTime = st.st_ctimespec.tv_sec;
+        commonStat->BlockSize = st.st_blksize;
+        commonStat->DeviceId = st.st_dev;
+        commonStat->NumberOfBlocks = st.st_blocks;
+        commonStat->IsBlockDevice = S_ISBLK(st.st_mode);
+        commonStat->IsCharacterDevice = S_ISCHR(st.st_mode);
+        commonStat->IsDirectory = S_ISDIR(st.st_mode);
+        commonStat->IsFile = S_ISREG(st.st_mode);
+        commonStat->IsNamedPipe = S_ISFIFO(st.st_mode);
+        commonStat->IsSocket = S_ISSOCK(st.st_mode);
+        commonStat->IsSymbolicLink = S_ISLNK(st.st_mode);
+        return 0;
+    }
+    return -1;
+}
+

--- a/src/libpsl-native/src/getcommonstat.cpp
+++ b/src/libpsl-native/src/getcommonstat.cpp
@@ -33,11 +33,11 @@ int GetCommonStat(const char* path, struct CommonStat* commonStat)
 #if defined (__APPLE__)
         commonStat->AccessTime   = st.st_atimespec.tv_sec;
         commonStat->ModifiedTime = st.st_mtimespec.tv_sec;
-        commonStat->CreationTime = st.st_ctimespec.tv_sec;
+        commonStat->ChangeTime = st.st_ctimespec.tv_sec;
 #else
         commonStat->AccessTime   = st.st_atime;
         commonStat->ModifiedTime = st.st_mtime;
-        commonStat->CreationTime = st.st_ctime;
+        commonStat->ChangeTime = st.st_ctime;
 #endif
         commonStat->BlockSize = st.st_blksize;
         commonStat->DeviceId = st.st_dev;

--- a/src/libpsl-native/src/getcommonstat.cpp
+++ b/src/libpsl-native/src/getcommonstat.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! @brief returns the stat of a file
+
+#include "getcommonstat.h"
+
+#include <errno.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <string.h>
+#include <unistd.h>
+
+// Provide a common structure for the various different stat structures
+int GetCommonStat(const char* path, struct CommonStat* commonStat)
+{
+    struct stat st;
+    struct CommonStat cs;
+    if (GetStat(path, &st) == 0)
+    {
+        cs.Inode = st.st_ino;
+        cs.IsDirectory = S_ISDIR(st.st_mode);
+        cs.IsFile = S_ISREG(st.st_mode);
+        cs.IsBlockDevice = S_ISBLK(st.st_mode);
+        cs.IsCharacterDevice = S_ISCHR(st.st_mode);
+        cs.IsNamedPipe = S_ISFIFO(st.st_mode);
+        cs.IsSocket = S_ISSOCK(st.st_mode);
+        cs.Mode = st.st_mode;
+        cs.UserId = st.st_uid;
+        cs.GroupId = st.st_gid;
+        commonStat = &cs;
+        return 0;
+    }
+    return -1;
+}

--- a/src/libpsl-native/src/getcommonstat.cpp
+++ b/src/libpsl-native/src/getcommonstat.cpp
@@ -30,9 +30,15 @@ int GetCommonLStat(const char* path, struct CommonStat* commonStat)
         commonStat->GroupId = st.st_gid;
         commonStat->HardlinkCount = st.st_nlink;
         commonStat->Size = st.st_size;
-        commonStat->AccessTime = st.st_atimespec.tv_sec;
+#if defined (__APPLE__)
+        commonStat->AccessTime   = st.st_atimespec.tv_sec;
         commonStat->ModifiedTime = st.st_mtimespec.tv_sec;
         commonStat->CreationTime = st.st_ctimespec.tv_sec;
+#else
+        commonStat->AccessTime   = st.st_atime;
+        commonStat->ModifiedTime = st.st_mtime;
+        commonStat->CreationTime = st.st_ctime;
+#endif
         commonStat->BlockSize = st.st_blksize;
         commonStat->DeviceId = st.st_dev;
         commonStat->NumberOfBlocks = st.st_blocks;
@@ -63,9 +69,15 @@ int GetCommonStat(const char* path, struct CommonStat* commonStat)
         commonStat->GroupId = st.st_gid;
         commonStat->HardlinkCount = st.st_nlink;
         commonStat->Size = st.st_size;
-        commonStat->AccessTime = st.st_atimespec.tv_sec;
+#if defined (__APPLE__)
+        commonStat->AccessTime   = st.st_atimespec.tv_sec;
         commonStat->ModifiedTime = st.st_mtimespec.tv_sec;
         commonStat->CreationTime = st.st_ctimespec.tv_sec;
+#else
+        commonStat->AccessTime   = st.st_atime;
+        commonStat->ModifiedTime = st.st_mtime;
+        commonStat->CreationTime = st.st_ctime;
+#endif
         commonStat->BlockSize = st.st_blksize;
         commonStat->DeviceId = st.st_dev;
         commonStat->NumberOfBlocks = st.st_blocks;

--- a/src/libpsl-native/src/getcommonstat.cpp
+++ b/src/libpsl-native/src/getcommonstat.cpp
@@ -49,6 +49,9 @@ int GetCommonStat(const char* path, struct CommonStat* commonStat)
         commonStat->IsNamedPipe = S_ISFIFO(st.st_mode);
         commonStat->IsSocket = S_ISSOCK(st.st_mode);
         commonStat->IsSymbolicLink = S_ISLNK(st.st_mode);
+        commonStat->IsSetUid = (st.st_mode & 0xE00) == S_ISUID;
+        commonStat->IsSetGid = (st.st_mode & 0xE00) == S_ISGID;
+        commonStat->IsSticky = (st.st_mode & 0xE00) == S_ISVTX;
         return 0;
     }
     return -1;

--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -19,7 +19,7 @@ struct CommonStat
     long Size;
     long AccessTime;
     long ModifiedTime;
-    long CreationTime;
+    long ChangeTime;
     long BlockSize;
     int DeviceId;
     int NumberOfBlocks;

--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -39,3 +39,4 @@ int32_t GetStat(const char* path, struct stat* buf);
 int GetCommonStat(const char* path, CommonStat* cs);
 
 PAL_END_EXTERNC
+

--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -30,6 +30,9 @@ struct CommonStat
     int IsCharacterDevice;
     int IsNamedPipe;
     int IsSocket;
+    int IsSetUid;
+    int IsSetGid;
+    int IsSticky;
 };
 
 int32_t GetStat(const char* path, struct stat* buf);

--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -15,6 +15,14 @@ struct CommonStat
     int Mode;
     int UserId;
     int GroupId;
+    int HardlinkCount;
+    long Size;
+    long AccessTime;
+    long ModifiedTime;
+    long CreationTime;
+    long BlockSize;
+    int DeviceId;
+    int NumberOfBlocks;
     int IsDirectory;
     int IsFile;
     int IsSymbolicLink;
@@ -26,5 +34,6 @@ struct CommonStat
 
 int32_t GetStat(const char* path, struct stat* buf);
 int GetCommonStat(const char* path, CommonStat* cs);
+int GetCommonLStat(const char* path, CommonStat* cs);
 
 PAL_END_EXTERNC

--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -34,6 +34,5 @@ struct CommonStat
 
 int32_t GetStat(const char* path, struct stat* buf);
 int GetCommonStat(const char* path, CommonStat* cs);
-int GetCommonLStat(const char* path, CommonStat* cs);
 
 PAL_END_EXTERNC

--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "pal.h"
+
+#include <sys/stat.h>
+
+PAL_BEGIN_EXTERNC
+
+struct CommonStat
+{
+    long Inode;
+    int Mode;
+    int UserId;
+    int GroupId;
+    int IsDirectory;
+    int IsFile;
+    int IsSymbolicLink;
+    int IsBlockDevice;
+    int IsCharacterDevice;
+    int IsNamedPipe;
+    int IsSocket;
+};
+
+int32_t GetStat(const char* path, struct stat* buf);
+int GetCommonStat(const char* path, CommonStat* cs);
+
+PAL_END_EXTERNC

--- a/src/libpsl-native/src/getgrgid.cpp
+++ b/src/libpsl-native/src/getgrgid.cpp
@@ -65,3 +65,4 @@ allocate:
     free(buf);
     return groupname;
 }
+

--- a/src/libpsl-native/src/getgrgid.cpp
+++ b/src/libpsl-native/src/getgrgid.cpp
@@ -53,7 +53,7 @@ allocate:
         return NULL;
     }
 
-    // no result
+    // no group found
     if (result == NULL)
     {
         return NULL;

--- a/src/libpsl-native/src/getgrgid.cpp
+++ b/src/libpsl-native/src/getgrgid.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! @brief returns the groupname for a gid
+
+#include "getgrgid.h"
+
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <grp.h>
+#include <string.h>
+#include <unistd.h>
+
+//! @brief GetGrGid returns the groupname for a gid
+//!
+//! GetGrGid
+//!
+//! @param[in] gid
+//! @parblock
+//! The group identifier to lookup.
+//! @endparblock
+//!
+//! @retval groupname as UTF-8 string, or NULL if unsuccessful
+//!
+char* GetGrGid(gid_t gid)
+{
+    int32_t ret = 0;
+    struct group grp;
+    struct group* result = NULL;
+    char* buf;
+
+    int buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (buflen < 1)
+    {
+        buflen = 2048;
+    }
+
+allocate:
+    buf = (char*)calloc(buflen, sizeof(char));
+
+    errno = 0;
+    ret = getgrgid_r(gid, &grp, buf, buflen, &result);
+
+    if (ret != 0)
+    {
+        if (errno == ERANGE)
+        {
+            free(buf);
+            buflen *= 2;
+            goto allocate;
+        }
+        return NULL;
+    }
+
+    // no result
+    if (result == NULL)
+    {
+        return NULL;
+    }
+
+    // allocate copy on heap so CLR can free it
+    size_t userlen = strnlen(grp.gr_name, buflen);
+    char* groupname = strndup(grp.gr_name, userlen);
+    free(buf);
+    return groupname;
+}

--- a/src/libpsl-native/src/getgrgid.h
+++ b/src/libpsl-native/src/getgrgid.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "pal.h"
+
+#include <sys/types.h>
+
+PAL_BEGIN_EXTERNC
+
+char* GetGrGid(gid_t gid);
+
+PAL_END_EXTERNC

--- a/src/libpsl-native/src/getgrgid.h
+++ b/src/libpsl-native/src/getgrgid.h
@@ -12,3 +12,4 @@ PAL_BEGIN_EXTERNC
 char* GetGrGid(gid_t gid);
 
 PAL_END_EXTERNC
+

--- a/src/libpsl-native/src/getlstat.cpp
+++ b/src/libpsl-native/src/getlstat.cpp
@@ -45,3 +45,4 @@ int32_t GetLStat(const char* path, struct stat* buf)
 
     return lstat(path, buf);
 }
+

--- a/src/libpsl-native/src/getlstat.cpp
+++ b/src/libpsl-native/src/getlstat.cpp
@@ -3,7 +3,7 @@
 
 //! @brief returns the stat of a file
 
-#include "getstat.h"
+#include "getlstat.h"
 
 #include <errno.h>
 #include <assert.h>
@@ -38,11 +38,10 @@
 // use externally defined structs in managed code has proven to be buggy
 // (memory corruption issues due to layout difference between platforms)
 // see https://github.com/dotnet/corefx/issues/29700#issuecomment-389313075
-int32_t GetStat(const char* path, struct stat* buf)
+int32_t GetLStat(const char* path, struct stat* buf)
 {
     assert(path);
     errno = 0;
 
-    return stat(path, buf);
+    return lstat(path, buf);
 }
-

--- a/src/libpsl-native/src/getlstat.h
+++ b/src/libpsl-native/src/getlstat.h
@@ -12,3 +12,4 @@ PAL_BEGIN_EXTERNC
 int32_t GetLStat(const char* path, struct stat* buf);
 
 PAL_END_EXTERNC
+

--- a/src/libpsl-native/src/getlstat.h
+++ b/src/libpsl-native/src/getlstat.h
@@ -9,6 +9,6 @@
 
 PAL_BEGIN_EXTERNC
 
-int32_t GetStat(const char* path, struct stat* buf);
+int32_t GetLStat(const char* path, struct stat* buf);
 
 PAL_END_EXTERNC

--- a/src/libpsl-native/src/getstat.cpp
+++ b/src/libpsl-native/src/getstat.cpp
@@ -45,3 +45,16 @@ int32_t GetStat(const char* path, struct stat* buf)
 
     return stat(path, buf);
 }
+
+
+// DO NOT use in managed code
+// use externally defined structs in managed code has proven to be buggy
+// (memory corruption issues due to layout difference between platforms)
+// see https://github.com/dotnet/corefx/issues/29700#issuecomment-389313075
+int32_t GetLStat(const char* path, struct stat* buf)
+{
+    assert(path);
+    errno = 0;
+
+    return lstat(path, buf);
+}

--- a/src/libpsl-native/src/getstat.h
+++ b/src/libpsl-native/src/getstat.h
@@ -10,5 +10,6 @@
 PAL_BEGIN_EXTERNC
 
 int32_t GetStat(const char* path, struct stat* buf);
+int32_t GetLStat(const char* path, struct stat* buf);
 
 PAL_END_EXTERNC

--- a/src/libpsl-native/src/isdirectory.cpp
+++ b/src/libpsl-native/src/isdirectory.cpp
@@ -15,6 +15,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <stdio.h>
+
 //! @brief returns if the path is a directory; uses stat and so follows symlinks
 //!
 //! IsDirectory

--- a/src/libpsl-native/src/isdirectory.cpp
+++ b/src/libpsl-native/src/isdirectory.cpp
@@ -43,3 +43,4 @@ bool IsDirectory(const char* path)
 
     return S_ISDIR(buf.st_mode);
 }
+

--- a/src/libpsl-native/test/CMakeLists.txt
+++ b/src/libpsl-native/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(psl-native-test
   test-getuserfrompid.cpp
   test-getcurrentprocessid.cpp
   test-getcomputername.cpp
+  test-getcommonstat.cpp
   test-getlinkcount.cpp
   test-isdirectory.cpp
   test-isfile.cpp

--- a/src/libpsl-native/test/CMakeLists.txt
+++ b/src/libpsl-native/test/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(psl-native-test
   test-getcomputername.cpp
   test-getcommonstat.cpp
   test-getlinkcount.cpp
+  test-getgrgid.cpp
+  test-getpwuid.cpp
   test-isdirectory.cpp
   test-isfile.cpp
   test-issymlink.cpp

--- a/src/libpsl-native/test/CMakeLists.txt
+++ b/src/libpsl-native/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(psl-native-test
   test-getcurrentprocessid.cpp
   test-getcomputername.cpp
   test-getcommonstat.cpp
+  test-getcommonlstat.cpp
   test-getlinkcount.cpp
   test-getgrgid.cpp
   test-getpwuid.cpp

--- a/src/libpsl-native/test/test-getcommonlstat.cpp
+++ b/src/libpsl-native/test/test-getcommonlstat.cpp
@@ -66,7 +66,7 @@ TEST(GetCommonLStat, GetGroupId)
     pclose(p);
     GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
-    EXPECT_EQ(gid, cs.UserId);
+    EXPECT_EQ(gid, cs.GroupId);
 }
 
 TEST(GetCommonLStat, GetInodeNumber)

--- a/src/libpsl-native/test/test-getcommonlstat.cpp
+++ b/src/libpsl-native/test/test-getcommonlstat.cpp
@@ -219,7 +219,7 @@ TEST(GetCommonLStat, GetCTime)
     pclose(p);
     GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
-    EXPECT_EQ(cTime, cs.CreationTime);
+    EXPECT_EQ(cTime, cs.ChangeTime);
 }
 
 TEST(GetCommonLStat, Mode001)

--- a/src/libpsl-native/test/test-getcommonlstat.cpp
+++ b/src/libpsl-native/test/test-getcommonlstat.cpp
@@ -231,6 +231,7 @@ TEST(GetCommonLStat, Mode001)
     CommonStat cs;
     strcpy(fname, ftemplate.c_str());
     fd = mkstemp(fname);
+    EXPECT_NE(fd, -1);
     chmod(fname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH);
     lstat(fname, &buffer);
     GetCommonLStat(fname, &cs);
@@ -247,6 +248,7 @@ TEST(GetCommonLStat, Mode002)
     CommonStat cs;
     strcpy(fname, ftemplate.c_str());
     fd = mkstemp(fname);
+    EXPECT_NE(fd, -1);
     chmod(fname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH | S_ISUID );
     lstat(fname, &buffer);
     GetCommonLStat(fname, &cs);
@@ -263,6 +265,7 @@ TEST(GetCommonLStat, Mode003)
     CommonStat cs;
     strcpy(fname, ftemplate.c_str());
     fd = mkstemp(fname);
+    EXPECT_NE(fd, -1);
     chmod(fname, S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH | S_ISGID );
     lstat(fname, &buffer);
     GetCommonLStat(fname, &cs);
@@ -279,6 +282,7 @@ TEST(GetCommonLStat, Mode004)
     CommonStat cs;
     strcpy(dname, ftemplate.c_str());
     fd = mkdtemp(dname);
+    EXPECT_NE(fd, ftemplate);
     chmod(dname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH | S_ISVTX );
     lstat(dname, &buffer);
     GetCommonLStat(dname, &cs);

--- a/src/libpsl-native/test/test-getcommonlstat.cpp
+++ b/src/libpsl-native/test/test-getcommonlstat.cpp
@@ -221,3 +221,68 @@ TEST(GetCommonLStat, GetCTime)
     EXPECT_EQ(result, 1);
     EXPECT_EQ(cTime, cs.CreationTime);
 }
+
+TEST(GetCommonLStat, Mode001)
+{
+    const std::string ftemplate = "/tmp/CommonStatModeF_XXXXXX";
+    char fname[PATH_MAX];
+    struct stat buffer;
+    int fd;
+    CommonStat cs;
+    strcpy(fname, ftemplate.c_str());
+    fd = mkstemp(fname);
+    chmod(fname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH);
+    lstat(fname, &buffer);
+    GetCommonLStat(fname, &cs);
+    unlink(fname);
+    EXPECT_EQ(cs.Mode, buffer.st_mode);
+}
+
+TEST(GetCommonLStat, Mode002)
+{
+    const std::string ftemplate = "/tmp/CommonStatModeF_XXXXXX";
+    char fname[PATH_MAX];
+    struct stat buffer;
+    int fd;
+    CommonStat cs;
+    strcpy(fname, ftemplate.c_str());
+    fd = mkstemp(fname);
+    chmod(fname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH | S_ISUID );
+    lstat(fname, &buffer);
+    GetCommonLStat(fname, &cs);
+    unlink(fname);
+    EXPECT_EQ(cs.Mode, buffer.st_mode);
+}
+
+TEST(GetCommonLStat, Mode003)
+{
+    const std::string ftemplate = "/tmp/CommonStatModeF_XXXXXX";
+    char fname[PATH_MAX];
+    struct stat buffer;
+    int fd;
+    CommonStat cs;
+    strcpy(fname, ftemplate.c_str());
+    fd = mkstemp(fname);
+    chmod(fname, S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH | S_ISGID );
+    lstat(fname, &buffer);
+    GetCommonLStat(fname, &cs);
+    unlink(fname);
+    EXPECT_EQ(cs.Mode, buffer.st_mode);
+}
+
+TEST(GetCommonLStat, Mode004)
+{
+    const std::string ftemplate = "/tmp/CommonStatModeD_XXXXXX";
+    char dname[PATH_MAX];
+    struct stat buffer;
+    char * fd;
+    CommonStat cs;
+    strcpy(dname, ftemplate.c_str());
+    fd = mkdtemp(dname);
+    chmod(dname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH | S_ISVTX );
+    lstat(dname, &buffer);
+    GetCommonLStat(dname, &cs);
+    rmdir(dname);
+    EXPECT_EQ(cs.Mode, buffer.st_mode);
+}
+

--- a/src/libpsl-native/test/test-getcommonlstat.cpp
+++ b/src/libpsl-native/test/test-getcommonlstat.cpp
@@ -7,35 +7,35 @@
 #include <errno.h>
 #include <unistd.h>
 #include "isdirectory.h"
-#include "getcommonstat.h"
+#include "getcommonlstat.h"
 
-TEST(GetCommonStat, RootIsDirectory)
+TEST(GetCommonLStat, RootIsDirectory)
 {
     CommonStat cs;
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     bool isDir = IsDirectory("/");
-    bool fromCommonStat = (bool)cs.IsDirectory;
-    EXPECT_EQ(isDir, fromCommonStat);
+    bool fromCommonLStat = (bool)cs.IsDirectory;
+    EXPECT_EQ(isDir, fromCommonLStat);
 }
 
-TEST(GetCommonStat, BinLsIsNotDirectory)
+TEST(GetCommonLStat, BinLsIsNotDirectory)
 {
     CommonStat cs;
-    GetCommonStat("/bin/ls", &cs);
+    GetCommonLStat("/bin/ls", &cs);
     bool isDir = IsDirectory("/bin/ls");
-    bool fromCommonStat = (bool)cs.IsDirectory;
-    EXPECT_EQ(isDir, fromCommonStat);
+    bool fromCommonLStat = (bool)cs.IsDirectory;
+    EXPECT_EQ(isDir, fromCommonLStat);
 }
 
 
-TEST(GetCommonStat, ReturnsFalseForFakeDirectory)
+TEST(GetCommonLStat, ReturnsFalseForFakeDirectory)
 {
     CommonStat cs;
-    int badDir = GetCommonStat("/A/Really/Bad/Directory",&cs);
+    int badDir = GetCommonLStat("/A/Really/Bad/Directory",&cs);
     EXPECT_EQ(badDir, -1);
 }
 
-TEST(GetCommonStat, GetOwnerIdOfRoot)
+TEST(GetCommonLStat, GetOwnerIdOfRoot)
 {
     FILE *p;
     CommonStat cs;
@@ -47,12 +47,12 @@ TEST(GetCommonStat, GetOwnerIdOfRoot)
     int uid = -1;
     int result = fscanf(p, "%d", &uid);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(uid, cs.UserId);
 }
 
-TEST(GetCommonStat, GetGroupId)
+TEST(GetCommonLStat, GetGroupId)
 {
     FILE *p;
     CommonStat cs;
@@ -64,12 +64,12 @@ TEST(GetCommonStat, GetGroupId)
     int gid = -1;
     int result = fscanf(p, "%d", &gid);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(gid, cs.UserId);
 }
 
-TEST(GetCommonStat, GetInodeNumber)
+TEST(GetCommonLStat, GetInodeNumber)
 {
     FILE *p;
     CommonStat cs;
@@ -81,29 +81,12 @@ TEST(GetCommonStat, GetInodeNumber)
     long inode = -1;
     int result = fscanf(p, "%ld", &inode);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(inode, cs.Inode);
 }
 
-TEST(GetCommonStat, GetMode)
-{
-    FILE *p;
-    CommonStat cs;
-#if defined (__APPLE__)
-     p = popen("/usr/bin/stat -f %p /", "r");
-#else
-     p = popen("/usr/bin/stat -c %f /", "r");
-#endif
-    long mode = -1;
-    int result = fscanf(p, "%lo", &mode);
-    pclose(p);
-    GetCommonStat("/", &cs);
-    EXPECT_EQ(result, 1);
-    EXPECT_EQ(mode, cs.Mode);
-}
-
-TEST(GetCommonStat, GetSize)
+TEST(GetCommonLStat, GetSize)
 {
     FILE *p;
     CommonStat cs;
@@ -115,12 +98,12 @@ TEST(GetCommonStat, GetSize)
     long size = -1;
     int result = fscanf(p, "%ld", &size);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(size, cs.Size);
 }
 
-TEST(GetCommonStat, GetBlockSize)
+TEST(GetCommonLStat, GetBlockSize)
 {
     FILE *p;
     CommonStat cs;
@@ -132,12 +115,12 @@ TEST(GetCommonStat, GetBlockSize)
     long bSize = -1;
     int result = fscanf(p, "%ld", &bSize);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(bSize, cs.BlockSize);
 }
 
-TEST(GetCommonStat, GetBlockCount)
+TEST(GetCommonLStat, GetBlockCount)
 {
     FILE *p;
     CommonStat cs;
@@ -149,12 +132,12 @@ TEST(GetCommonStat, GetBlockCount)
     int bSize = -1;
     int result = fscanf(p, "%d", &bSize);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(bSize, cs.NumberOfBlocks);
 }
 
-TEST(GetCommonStat, GetLinkCount)
+TEST(GetCommonLStat, GetLinkCount)
 {
     FILE *p;
     CommonStat cs;
@@ -166,12 +149,12 @@ TEST(GetCommonStat, GetLinkCount)
     int linkcount = -1;
     int result = fscanf(p, "%d", &linkcount);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(linkcount, cs.HardlinkCount);
 }
 
-TEST(GetCommonStat, GetDeviceId)
+TEST(GetCommonLStat, GetDeviceId)
 {
     FILE *p;
     CommonStat cs;
@@ -183,12 +166,12 @@ TEST(GetCommonStat, GetDeviceId)
     int deviceId = -1;
     int result = fscanf(p, "%d", &deviceId);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(deviceId, cs.DeviceId);
 }
 
-TEST(GetCommonStat, GetATime)
+TEST(GetCommonLStat, GetATime)
 {
     FILE *p;
     CommonStat cs;
@@ -200,12 +183,12 @@ TEST(GetCommonStat, GetATime)
     long aTime = -1;
     int result = fscanf(p, "%ld", &aTime);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(aTime, cs.AccessTime);
 }
 
-TEST(GetCommonStat, GetMTime)
+TEST(GetCommonLStat, GetMTime)
 {
     FILE *p;
     CommonStat cs;
@@ -217,12 +200,12 @@ TEST(GetCommonStat, GetMTime)
     long mTime = -1;
     int result = fscanf(p, "%ld", &mTime);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(mTime, cs.ModifiedTime);
 }
 
-TEST(GetCommonStat, GetCTime)
+TEST(GetCommonLStat, GetCTime)
 {
     FILE *p;
     CommonStat cs;
@@ -234,7 +217,7 @@ TEST(GetCommonStat, GetCTime)
     long cTime = -1;
     int result = fscanf(p, "%ld", &cTime);
     pclose(p);
-    GetCommonStat("/", &cs);
+    GetCommonLStat("/", &cs);
     EXPECT_EQ(result, 1);
     EXPECT_EQ(cTime, cs.CreationTime);
 }

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -251,6 +251,7 @@ TEST(GetCommonStat, Mode001)
     CommonStat cs;
     strcpy(fname, ftemplate.c_str());
     fd = mkstemp(fname);
+    EXPECT_NE(fd, -1);
     chmod(fname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH);
     stat(fname, &buffer);
     GetCommonStat(fname, &cs);
@@ -267,6 +268,7 @@ TEST(GetCommonStat, Mode002)
     CommonStat cs;
     strcpy(fname, ftemplate.c_str());
     fd = mkstemp(fname);
+    EXPECT_NE(fd, -1);
     chmod(fname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH | S_ISUID );
     stat(fname, &buffer);
     GetCommonStat(fname, &cs);
@@ -283,6 +285,7 @@ TEST(GetCommonStat, Mode003)
     CommonStat cs;
     strcpy(fname, ftemplate.c_str());
     fd = mkstemp(fname);
+    EXPECT_NE(fd, -1);
     chmod(fname, S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH | S_ISGID );
     stat(fname, &buffer);
     GetCommonStat(fname, &cs);
@@ -299,6 +302,7 @@ TEST(GetCommonStat, Mode004)
     CommonStat cs;
     strcpy(dname, ftemplate.c_str());
     fd = mkdtemp(dname);
+    EXPECT_NE(fd, ftemplate);
     chmod(dname, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH | S_ISVTX );
     stat(dname, &buffer);
     GetCommonStat(dname, &cs);

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! @brief Tests IsDirectory
+
+#include <gtest/gtest.h>
+#include <errno.h>
+#include <unistd.h>
+#include "isdirectory.h"
+#include "getstatcommon.h"
+
+TEST(IsDirectoryTest, RootIsDirectory)
+{
+    EXPECT_TRUE(IsDirectory("/"));
+}
+
+TEST(IsDirectoryTest, BinLsIsNotDirectory)
+{
+    EXPECT_FALSE(IsDirectory("/bin/ls"));
+}
+
+
+TEST(IsDirectoryTest, ReturnsFalseForFakeDirectory)
+{
+    EXPECT_FALSE(IsDirectory("SomeMadeUpFileNameThatDoesNotExist"));
+    EXPECT_EQ(ENOENT, errno);
+}

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -239,7 +239,7 @@ TEST(GetCommonStat, GetCTime)
     pclose(p);
     GetCommonStat("/", &cs);
     EXPECT_EQ(result, 1);
-    EXPECT_EQ(cTime, cs.CreationTime);
+    EXPECT_EQ(cTime, cs.ChangeTime);
 }
 
 TEST(GetCommonStat, Mode001)

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -90,13 +90,14 @@ TEST(GetCommonStat, GetMode)
 {
     FILE *p;
     CommonStat cs;
+    unsigned int mode = -1;
 #if defined (__APPLE__)
-     p = popen("/usr/bin/stat -f %p /", "r");
-#else
-     p = popen("/usr/bin/stat -c %f /", "r");
-#endif
-    long mode = -1;
+    p = popen("/usr/bin/stat -f %p /", "r");
     int result = fscanf(p, "%lo", &mode);
+#else
+    p = popen("/usr/bin/stat -c %f /", "r");
+    int result = fscanf(p, "%x", &mode);
+#endif
     pclose(p);
     GetCommonStat("/", &cs);
     EXPECT_EQ(result, 1);

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -68,7 +68,7 @@ TEST(GetCommonStat, GetGroupId)
     pclose(p);
     GetCommonStat("/", &cs);
     EXPECT_EQ(result, 1);
-    EXPECT_EQ(gid, cs.UserId);
+    EXPECT_EQ(gid, cs.GroupId);
 }
 
 TEST(GetCommonStat, GetInodeNumber)

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -7,21 +7,206 @@
 #include <errno.h>
 #include <unistd.h>
 #include "isdirectory.h"
-#include "getstatcommon.h"
+#include "getcommonstat.h"
 
-TEST(IsDirectoryTest, RootIsDirectory)
+TEST(GetCommonStat, RootIsDirectory)
 {
-    EXPECT_TRUE(IsDirectory("/"));
+    CommonStat cs;
+    GetCommonStat("/", &cs);
+    bool isDir = IsDirectory("/");
+    bool fromCommonStat = (bool)cs.IsDirectory;
+    EXPECT_EQ(isDir, fromCommonStat);
 }
 
-TEST(IsDirectoryTest, BinLsIsNotDirectory)
+TEST(GetCommonStat, BinLsIsNotDirectory)
 {
-    EXPECT_FALSE(IsDirectory("/bin/ls"));
+    CommonStat cs;
+    GetCommonStat("/bin/ls", &cs);
+    bool isDir = IsDirectory("/bin/ls");
+    bool fromCommonStat = (bool)cs.IsDirectory;
+    EXPECT_EQ(isDir, fromCommonStat);
 }
 
 
-TEST(IsDirectoryTest, ReturnsFalseForFakeDirectory)
+TEST(GetCommonStat, ReturnsFalseForFakeDirectory)
 {
-    EXPECT_FALSE(IsDirectory("SomeMadeUpFileNameThatDoesNotExist"));
-    EXPECT_EQ(ENOENT, errno);
+    CommonStat cs;
+    int badDir = GetCommonStat("/A/Really/Bad/Directory",&cs);
+    EXPECT_EQ(badDir, -1);
+}
+
+TEST(GetCommonStat, GetOwnerIdOfRoot)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %u /", "r");
+#else
+     p = popen("/usr/bin/stat -c %u /", "r");
+#endif
+    int uid = -1;
+    fscanf(p, "%d", &uid);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(uid, cs.UserId);
+}
+
+TEST(GetCommonStat, GetGroupId)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %g /", "r");
+#else
+     p = popen("/usr/bin/stat -c %g /", "r");
+#endif
+    int gid = -1;
+    fscanf(p, "%d", &gid);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(gid, cs.UserId);
+}
+
+TEST(GetCommonStat, GetInodeNumber)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %i /", "r");
+#else
+     p = popen("/usr/bin/stat -c %i /", "r");
+#endif
+    long inode = -1;
+    fscanf(p, "%ld", &inode);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(inode, cs.Inode);
+}
+
+TEST(GetCommonStat, GetSize)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %z /", "r");
+#else
+     p = popen("/usr/bin/stat -c %z /", "r");
+#endif
+    long size = -1;
+    fscanf(p, "%ld", &size);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(size, cs.Size);
+}
+
+TEST(GetCommonStat, GetBlockSize)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %k /", "r");
+#else
+     p = popen("/usr/bin/stat -c %k /", "r");
+#endif
+    long bSize = -1;
+    fscanf(p, "%ld", &bSize);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(bSize, cs.BlockSize);
+}
+
+TEST(GetCommonStat, GetBlockCount)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %b /", "r");
+#else
+     p = popen("/usr/bin/stat -c %b /", "r");
+#endif
+    int bSize = -1;
+    fscanf(p, "%d", &bSize);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(bSize, cs.NumberOfBlocks);
+}
+
+TEST(GetCommonStat, GetLinkCount)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %l /", "r");
+#else
+     p = popen("/usr/bin/stat -c %l /", "r");
+#endif
+    int linkcount = -1;
+    fscanf(p, "%d", &linkcount);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(linkcount, cs.HardlinkCount);
+}
+
+TEST(GetCommonStat, GetDeviceId)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %d /", "r");
+#else
+     p = popen("/usr/bin/stat -c %d /", "r");
+#endif
+    int deviceId = -1;
+    fscanf(p, "%d", &deviceId);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(deviceId, cs.DeviceId);
+}
+
+TEST(GetCommonStat, GetATime)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %a /", "r");
+#else
+     p = popen("/usr/bin/stat -c %a /", "r");
+#endif
+    long aTime = -1;
+    fscanf(p, "%ld", &aTime);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(aTime, cs.AccessTime);
+}
+
+TEST(GetCommonStat, GetMTime)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %m /", "r");
+#else
+     p = popen("/usr/bin/stat -c %m /", "r");
+#endif
+    long mTime = -1;
+    fscanf(p, "%ld", &mTime);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(mTime, cs.ModifiedTime);
+}
+
+TEST(GetCommonStat, GetCTime)
+{
+    FILE *p;
+    CommonStat cs;
+#if defined (__APPLE__)
+     p = popen("/usr/bin/stat -f %c /", "r");
+#else
+     p = popen("/usr/bin/stat -c %c /", "r");
+#endif
+    long cTime = -1;
+    fscanf(p, "%ld", &cTime);
+    pclose(p);
+    GetCommonStat("/", &cs);
+    EXPECT_EQ(cTime, cs.CreationTime);
 }

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -45,9 +45,10 @@ TEST(GetCommonStat, GetOwnerIdOfRoot)
      p = popen("/usr/bin/stat -c %u /", "r");
 #endif
     int uid = -1;
-    fscanf(p, "%d", &uid);
+    int result = fscanf(p, "%d", &uid);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(uid, cs.UserId);
 }
 
@@ -61,9 +62,10 @@ TEST(GetCommonStat, GetGroupId)
      p = popen("/usr/bin/stat -c %g /", "r");
 #endif
     int gid = -1;
-    fscanf(p, "%d", &gid);
+    int result = fscanf(p, "%d", &gid);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(gid, cs.UserId);
 }
 
@@ -77,9 +79,10 @@ TEST(GetCommonStat, GetInodeNumber)
      p = popen("/usr/bin/stat -c %i /", "r");
 #endif
     long inode = -1;
-    fscanf(p, "%ld", &inode);
+    int result = fscanf(p, "%ld", &inode);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(inode, cs.Inode);
 }
 
@@ -90,12 +93,13 @@ TEST(GetCommonStat, GetSize)
 #if defined (__APPLE__)
      p = popen("/usr/bin/stat -f %z /", "r");
 #else
-     p = popen("/usr/bin/stat -c %z /", "r");
+     p = popen("/usr/bin/stat -c %s /", "r");
 #endif
     long size = -1;
-    fscanf(p, "%ld", &size);
+    int result = fscanf(p, "%ld", &size);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(size, cs.Size);
 }
 
@@ -106,12 +110,13 @@ TEST(GetCommonStat, GetBlockSize)
 #if defined (__APPLE__)
      p = popen("/usr/bin/stat -f %k /", "r");
 #else
-     p = popen("/usr/bin/stat -c %k /", "r");
+     p = popen("/usr/bin/stat -c %o /", "r");
 #endif
     long bSize = -1;
-    fscanf(p, "%ld", &bSize);
+    int result = fscanf(p, "%ld", &bSize);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(bSize, cs.BlockSize);
 }
 
@@ -125,9 +130,10 @@ TEST(GetCommonStat, GetBlockCount)
      p = popen("/usr/bin/stat -c %b /", "r");
 #endif
     int bSize = -1;
-    fscanf(p, "%d", &bSize);
+    int result = fscanf(p, "%d", &bSize);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(bSize, cs.NumberOfBlocks);
 }
 
@@ -138,12 +144,13 @@ TEST(GetCommonStat, GetLinkCount)
 #if defined (__APPLE__)
      p = popen("/usr/bin/stat -f %l /", "r");
 #else
-     p = popen("/usr/bin/stat -c %l /", "r");
+     p = popen("/usr/bin/stat -c %h /", "r");
 #endif
     int linkcount = -1;
-    fscanf(p, "%d", &linkcount);
+    int result = fscanf(p, "%d", &linkcount);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(linkcount, cs.HardlinkCount);
 }
 
@@ -157,9 +164,10 @@ TEST(GetCommonStat, GetDeviceId)
      p = popen("/usr/bin/stat -c %d /", "r");
 #endif
     int deviceId = -1;
-    fscanf(p, "%d", &deviceId);
+    int result = fscanf(p, "%d", &deviceId);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(deviceId, cs.DeviceId);
 }
 
@@ -170,12 +178,13 @@ TEST(GetCommonStat, GetATime)
 #if defined (__APPLE__)
      p = popen("/usr/bin/stat -f %a /", "r");
 #else
-     p = popen("/usr/bin/stat -c %a /", "r");
+     p = popen("/usr/bin/stat -c %X /", "r");
 #endif
     long aTime = -1;
-    fscanf(p, "%ld", &aTime);
+    int result = fscanf(p, "%ld", &aTime);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(aTime, cs.AccessTime);
 }
 
@@ -186,12 +195,13 @@ TEST(GetCommonStat, GetMTime)
 #if defined (__APPLE__)
      p = popen("/usr/bin/stat -f %m /", "r");
 #else
-     p = popen("/usr/bin/stat -c %m /", "r");
+     p = popen("/usr/bin/stat -c %Y /", "r");
 #endif
     long mTime = -1;
-    fscanf(p, "%ld", &mTime);
+    int result = fscanf(p, "%ld", &mTime);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(mTime, cs.ModifiedTime);
 }
 
@@ -202,11 +212,12 @@ TEST(GetCommonStat, GetCTime)
 #if defined (__APPLE__)
      p = popen("/usr/bin/stat -f %c /", "r");
 #else
-     p = popen("/usr/bin/stat -c %c /", "r");
+     p = popen("/usr/bin/stat -c %Z /", "r");
 #endif
     long cTime = -1;
-    fscanf(p, "%ld", &cTime);
+    int result = fscanf(p, "%ld", &cTime);
     pclose(p);
     GetCommonStat("/", &cs);
+    EXPECT_EQ(result, 1);
     EXPECT_EQ(cTime, cs.CreationTime);
 }

--- a/src/libpsl-native/test/test-getgrgid.cpp
+++ b/src/libpsl-native/test/test-getgrgid.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! @brief Unit tests for GetUserFromPid
+
+#include <gtest/gtest.h>
+#include <grp.h>
+#include "getgrgid.h"
+
+TEST(GetGrGid, Success)
+{
+    char* expected = getgrgid(getegid())->gr_name;
+    EXPECT_STREQ(GetGrGid(getegid()), expected);
+}

--- a/src/libpsl-native/test/test-getgrgid.cpp
+++ b/src/libpsl-native/test/test-getgrgid.cpp
@@ -12,3 +12,4 @@ TEST(GetGrGid, Success)
     char* expected = getgrgid(getegid())->gr_name;
     EXPECT_STREQ(GetGrGid(getegid()), expected);
 }
+

--- a/src/libpsl-native/test/test-getlinkcount.cpp
+++ b/src/libpsl-native/test/test-getlinkcount.cpp
@@ -33,6 +33,11 @@ protected:
         file = fileTemplateBuf;
     }
 
+    ~getLinkCountTest()
+    {
+       unlink(fileTemplateBuf);
+    }
+
     void createFileForTesting(const std::string &theFile)
     {
         std::ofstream ofs;
@@ -69,10 +74,14 @@ TEST_F(getLinkCountTest, LinkCountOfSinglyLinkedFile)
 {
     createFileForTesting(file);
     int32_t ret = GetLinkCount(file, &count);
+
+printf("001 %s\n", file);
+
+    removeFile(file);
+
     ASSERT_EQ(0, ret);
     EXPECT_EQ(1, count);
 
-    removeFile(file);
 }
 
 TEST_F(getLinkCountTest, LinkCountOfMultiplyLinkedFile)
@@ -80,10 +89,15 @@ TEST_F(getLinkCountTest, LinkCountOfMultiplyLinkedFile)
     createFileForTesting(file);
     std::string newFile = createHardLink(file);
     int32_t ret = GetLinkCount(file, &count);
-    ASSERT_EQ(0, ret);
-    EXPECT_EQ(2, count);
+
+printf("002 %s\n", file);
+printf("003 %s\n", newFile.c_str());
 
     removeFile(file);
     removeFile(newFile);
+
+    ASSERT_EQ(0, ret);
+    EXPECT_EQ(2, count);
+
 }
 

--- a/src/libpsl-native/test/test-getlinkcount.cpp
+++ b/src/libpsl-native/test/test-getlinkcount.cpp
@@ -75,8 +75,6 @@ TEST_F(getLinkCountTest, LinkCountOfSinglyLinkedFile)
     createFileForTesting(file);
     int32_t ret = GetLinkCount(file, &count);
 
-printf("001 %s\n", file);
-
     removeFile(file);
 
     ASSERT_EQ(0, ret);
@@ -89,9 +87,6 @@ TEST_F(getLinkCountTest, LinkCountOfMultiplyLinkedFile)
     createFileForTesting(file);
     std::string newFile = createHardLink(file);
     int32_t ret = GetLinkCount(file, &count);
-
-printf("002 %s\n", file);
-printf("003 %s\n", newFile.c_str());
 
     removeFile(file);
     removeFile(newFile);

--- a/src/libpsl-native/test/test-getpwuid.cpp
+++ b/src/libpsl-native/test/test-getpwuid.cpp
@@ -12,3 +12,4 @@ TEST(GetPwUid, Success)
     char* expected = getpwuid(geteuid())->pw_name;
     EXPECT_STREQ(GetPwUid(geteuid()), expected);
 }
+

--- a/src/libpsl-native/test/test-getpwuid.cpp
+++ b/src/libpsl-native/test/test-getpwuid.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//! @brief Unit tests for GetUserFromPid
+
+#include <gtest/gtest.h>
+#include <pwd.h>
+#include "getpwuid.h"
+
+TEST(GetPwUid, Success)
+{
+    char* expected = getpwuid(geteuid())->pw_name;
+    EXPECT_STREQ(GetPwUid(geteuid()), expected);
+}


### PR DESCRIPTION
In preparation for adding a more unix output for Get-ChildItem, I'm adding a number of native calls in support of that:
* GetCommonStat
* GetCommonLStat
These return a synthetic stat structure which may be used on all our non-Windows platforms
* GetGrGid
This returns the group name for a gid
* GetLStat
* GetStat
These are used by GetCommonStat and GetCommonLStat