### PR TITLE
Update to not rely on sysctl.h if sysconf is available

### DIFF
--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(CheckIncludeFiles)
+include(CheckFunctionExists)
 
 add_library(psl-native SHARED
   getstat.cpp
@@ -28,8 +29,10 @@ add_library(psl-native SHARED
   createprocess.cpp
   nativesyslog.cpp)
 
+check_function_exists(sysconf HAVE_SYSCONF)
+
 check_include_files(
-    "sys/types.h;sys/sysctl.h"
+    "sys/sysctl.h"
     HAVE_SYS_SYSCTL_H)
 
 configure_file(

--- a/src/libpsl-native/src/getppid.cpp
+++ b/src/libpsl-native/src/getppid.cpp
@@ -7,7 +7,9 @@
 #include <sys/user.h>
 #include <sys/param.h>
 
-#if HAVE_SYS_SYSCTL_H
+#if HAVE_SYSCONF
+// do nothing
+#elif HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
 

--- a/src/libpsl-native/src/getuserfrompid.cpp
+++ b/src/libpsl-native/src/getuserfrompid.cpp
@@ -11,7 +11,9 @@
 #include <sstream>
 #include <errno.h>
 
-#if HAVE_SYSCONF
+#if __APPLE__
+#include <sys/sysctl.h>
+#elif HAVE_SYSCONF
 // do nothing
 #elif HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>

--- a/src/libpsl-native/src/getuserfrompid.cpp
+++ b/src/libpsl-native/src/getuserfrompid.cpp
@@ -11,7 +11,9 @@
 #include <sstream>
 #include <errno.h>
 
-#if HAVE_SYS_SYSCTL_H
+#if HAVE_SYSCONF
+// do nothing
+#elif HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
 

--- a/src/libpsl-native/src/pal_config.h.in
+++ b/src/libpsl-native/src/pal_config.h.in
@@ -1,3 +1,4 @@
 #pragma once
 
 #cmakedefine01 HAVE_SYS_SYSCTL_H
+#cmakedefine01 HAVE_SYSCONF


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell-Native/issues/33
