### PR TITLE
Change long to int64_t in common stat struct

### DIFF
--- a/src/libpsl-native/src/getcommonstat.h
+++ b/src/libpsl-native/src/getcommonstat.h
@@ -11,16 +11,16 @@ PAL_BEGIN_EXTERNC
 
 struct CommonStat
 {
-    long Inode;
+    int64_t Inode;
     int Mode;
     int UserId;
     int GroupId;
     int HardlinkCount;
-    long Size;
-    long AccessTime;
-    long ModifiedTime;
-    long ChangeTime;
-    long BlockSize;
+    int64_t Size;
+    int64_t AccessTime;
+    int64_t ModifiedTime;
+    int64_t ChangeTime;
+    int64_t BlockSize;
     int DeviceId;
     int NumberOfBlocks;
     int IsDirectory;

--- a/src/libpsl-native/test/test-getcommonstat.cpp
+++ b/src/libpsl-native/test/test-getcommonstat.cpp
@@ -274,6 +274,7 @@ TEST(GetCommonStat, Mode002)
     GetCommonStat(fname, &cs);
     unlink(fname);
     EXPECT_EQ(cs.Mode, buffer.st_mode);
+    EXPECT_EQ(cs.IsSetUid, 1);
 }
 
 TEST(GetCommonStat, Mode003)
@@ -291,6 +292,7 @@ TEST(GetCommonStat, Mode003)
     GetCommonStat(fname, &cs);
     unlink(fname);
     EXPECT_EQ(cs.Mode, buffer.st_mode);
+    // don't check for IsSetGid as that can vary from platform based on file system
 }
 
 TEST(GetCommonStat, Mode004)
@@ -308,5 +310,6 @@ TEST(GetCommonStat, Mode004)
     GetCommonStat(dname, &cs);
     rmdir(dname);
     EXPECT_EQ(cs.Mode, buffer.st_mode);
+    EXPECT_EQ(cs.IsSticky, 1);
 }
 


### PR DESCRIPTION
32bit platforms have a long as 4 bytes (raspbian), which caused the UnixStat calls in the experimental feature to have failures on that platform. By making it an int64_t I make sure that I get 8 bytes (as it is in C#).

I also added a couple of tests to test the IsSetUid and IsSticky properties of the getcommonstat api