### PR TITLE
Reverting previous change.

### DIFF
--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
@@ -584,15 +584,10 @@ private:
             return g_MANAGED_PLUGIN_ALREADY_LOADED;
         }
 
-// Not used for CORECLR plugins
-#if !CORECLR
-
         if ((NULL == wszVCLRVersion) || (NULL == wszVAppBase))
         {
             return g_INVALID_INPUT;
         }
-
-#endif
 
         do
         {
@@ -653,8 +648,6 @@ private:
     {
         unsigned int exitCode = EXIT_CODE_SUCCESS;
 
-// PowerShell core plugin does not depend on registered Windows PowerShell version.
-#if !CORECLR
         // Verify incoming powershell version format.
         int iPSMajorVersion = 0;
         int iPSMinorVersion = 0;
@@ -680,7 +673,6 @@ private:
         {
             requestedMonadMajorVersion = 1;
         }
-#endif
 
         wchar_t* wszMonadVersion = NULL;    // Allocated via ConstructPowerShellVersion || GetRegistryInfo
         wchar_t* wszTempCLRVersion = NULL;  // Allocated via GetRegistryInfo
@@ -690,8 +682,6 @@ private:
 
         do
         {
-// PowerShell core plugin does not depend on registered Windows PowerShell version.
-#if !CORECLR
             exitCode = ConstructPowerShellVersion(iPSMajorVersion, iPSMinorVersion, &wszMonadVersion);
             if (exitCode != EXIT_CODE_SUCCESS)
             {
@@ -722,11 +712,9 @@ private:
             {
                 break;
             }
-#endif
 
             if (!bIsPluginLoaded)
             {
-		// wszMgdPlugInFileName is ignored for CORECLR.
                 this->powerShellClrHost = PowerShellClrWorkerFactory(wszMgdPlugInFileName);
                 if (NULL == this->powerShellClrHost)
                 {
@@ -734,7 +722,6 @@ private:
                     break;
                 }
 
-		// wszMonadVersion, wszTempCLRVersion ignored for CORECLR.
                 exitCode = powerShellClrHost->LaunchClr(wszMonadVersion, wszTempCLRVersion, "PwrshPlugin");
                 if (EXIT_CODE_SUCCESS != exitCode)
                 {
@@ -744,10 +731,8 @@ private:
                     break;
                 }
 
-		// wszMgdPlugInFileName, wszTempCLRVersion, wszTempAppBase ignored for CORECLR.
                 exitCode = LoadManagedPlugIn(wszMgdPlugInFileName, wszTempCLRVersion, wszTempAppBase, &pErrorMsg);
             }
-#if !CORECLR
             else
             {
                 if (requestedMonadMajorVersion != iMajorVersion)
@@ -763,7 +748,6 @@ private:
                     exitCode = g_OPTION_SET_APP_BASE_NOT_MATCH;
                 }
             }
-#endif
         } while (false);
 
         if (NULL != wszMonadVersion)


### PR DESCRIPTION
This change reverts a previous change intended to remove PS Core dependency on Windows PowerShell.

This is just a test to see if this change affected WSMan client token passing.