### PR TITLE
libpsl-native: add KillProcess and WaitPid functions

### DIFF
--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -27,7 +27,9 @@ add_library(psl-native SHARED
   createsymlink.cpp
   followsymlink.cpp
   createprocess.cpp
-  nativesyslog.cpp)
+  nativesyslog.cpp
+  killprocess.cpp
+  waitpid.cpp)
 
 check_function_exists(sysconf HAVE_SYSCONF)
 

--- a/src/libpsl-native/src/killprocess.cpp
+++ b/src/libpsl-native/src/killprocess.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! @brief kill a process with SIGKILL
+
+#include "killprocess.h"
+
+#include <sys/types.h>
+#include <signal.h>
+
+//! @brief kill a process with SIGKILL
+//!
+//! KillProcess
+//!
+//! @param[in] pid
+//! @parblock
+//! The target PID to kill.
+//! @endparblock
+//!
+//! @retval true if signal successfully sent, false otherwise
+//!
+bool KillProcess(pid_t pid)
+{
+    return kill(pid, SIGKILL) == 0;
+}

--- a/src/libpsl-native/src/killprocess.h
+++ b/src/libpsl-native/src/killprocess.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "pal.h"
+#include <sys/types.h>
+
+PAL_BEGIN_EXTERNC
+
+bool KillProcess(pid_t pid);
+
+PAL_END_EXTERNC

--- a/src/libpsl-native/src/waitpid.cpp
+++ b/src/libpsl-native/src/waitpid.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! @brief wait for a child process to stop or terminate
+
+#include "waitpid.h"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+//! @brief wait for a child process to stop or terminate
+//!
+//! WaitPid
+//!
+//! @param[in] pid
+//! @parblock
+//! The target PID to wait for.
+//! @endparblock
+//!
+//! @param[in] nohang
+//! @parblock
+//! Whether to block while waiting for the process.
+//! @endparblock
+//!
+//! @retval PID of exited child, or -1 if error
+//!
+pid_t WaitPid(pid_t pid, bool nohang)
+{
+    return waitpid(pid, NULL, nohang ? WNOHANG : 0);
+}

--- a/src/libpsl-native/src/waitpid.h
+++ b/src/libpsl-native/src/waitpid.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "pal.h"
+#include <sys/types.h>
+
+PAL_BEGIN_EXTERNC
+
+pid_t WaitPid(pid_t pid, bool nohang);
+
+PAL_END_EXTERNC


### PR DESCRIPTION
These functions are used by powershell-unix to clean up SSH processes
after they exit.

First part of fixes for PowerShell/PowerShell#13356.