### PR TITLE
Fix APIScan by providing the required parameters

### DIFF
--- a/tools/releaseBuild/yaml/nuget.yml
+++ b/tools/releaseBuild/yaml/nuget.yml
@@ -65,32 +65,7 @@ steps:
   inputs:
     versionSpec: 5.3.1
 
-- powershell: |
-    $Branch = $env:BUILD_SOURCEBRANCH
-    $branchOnly = $Branch -replace '^refs/heads/';
-    $branchOnly = $branchOnly -replace '[_\-]'
-
-    $packageVersion = if($env:PACKAGE_VERSION -eq 'fromBranch' -or !$env:PACKAGE_VERSION)
-    {
-      if($Branch -match '^.*(release[-/])')
-      {
-        Write-verbose "release branch:" -verbose
-        $Branch -replace '^.*(release[-/]v)'
-      }
-      else
-      {
-        "0.0.0"
-      }
-    }
-    else {
-      "0.0.0"
-    }
-
-    $vstsCommandString = "vso[task.setvariable variable=NugetPackageVersion]$packageVersion"
-    Write-Verbose -Message "setting $Variable to $packageVersion" -Verbose
-    Write-Host -Object "##$vstsCommandString"
-
-  displayName: Set NuGetPackageVersion
+- template: setVersion.yml
 
 - powershell: |
    Import-Module $(Build.SourcesDirectory)\build.psm1
@@ -107,7 +82,7 @@ steps:
    $macOSZipPath = Join-Path "$(System.ArtifactsDirectory)/release" 'osx-symbols.zip'
    $psrpZipPath = Join-Path "$(System.ArtifactsDirectory)/release" 'psrp.zip'
 
-   Start-BuildPowerShellNativePackage -PackageRoot $PackageRoot -Version $(NugetPackageVersion) -WindowsX64ZipPath  $WindowsX64ZipPath -WindowsX86ZipPath $WindowsX86ZipPath -WindowsARMZipPath $WindowsARMZipPath  -WindowsARM64ZipPath  $WindowsARM64ZipPath -LinuxZipPath $LinuxZipPath -LinuxARMZipPath  $LinuxARMZipPath -LinuxARM64ZipPath $LinuxARM64ZipPath -LinuxAlpineZipPath $LinuxAlpineZipPath -macOSZipPath $macOSZipPath -psrpZipPath $psrpZipPath -NuGetOutputPath $(NuGetPackagePath)
+   Start-BuildPowerShellNativePackage -PackageRoot $PackageRoot -Version $(PackageVersion) -WindowsX64ZipPath  $WindowsX64ZipPath -WindowsX86ZipPath $WindowsX86ZipPath -WindowsARMZipPath $WindowsARMZipPath  -WindowsARM64ZipPath  $WindowsARM64ZipPath -LinuxZipPath $LinuxZipPath -LinuxARMZipPath  $LinuxARMZipPath -LinuxARM64ZipPath $LinuxARM64ZipPath -LinuxAlpineZipPath $LinuxAlpineZipPath -macOSZipPath $macOSZipPath -psrpZipPath $psrpZipPath -NuGetOutputPath $(NuGetPackagePath)
 
   displayName: 'Build NuGet package'
 
@@ -152,5 +127,5 @@ steps:
 - template: uploadArtifact.yml
   parameters:
     artifactPath: '$(System.ArtifactsDirectory)\signed'
-    artifactFilter: 'Microsoft.PowerShell.Native.$(NugetPackageVersion).nupkg'
+    artifactFilter: 'Microsoft.PowerShell.Native.$(PackageVersion).nupkg'
     artifactName: 'finalResults'

--- a/tools/releaseBuild/yaml/releaseBuild.yml
+++ b/tools/releaseBuild/yaml/releaseBuild.yml
@@ -110,6 +110,12 @@ stages:
     - download: current
       artifact: signed
 
+    - template: setVersion.yml
+
+    - pwsh: |
+        Get-ChildItem -Path 'ENV:'
+      displayName: Capture environment
+
     - powershell: |
         $null = New-Item $(PackageRoot) -ItemType Directory -Force -Verbose
         if(-not (Test-Path '$(Pipeline.Workspace)/release' ))
@@ -138,6 +144,10 @@ stages:
         Get-ChildItem -Recurse $extractedRoot -File
       displayName: 'Extract All Zips'
 
+    - pwsh: |
+        Write-Verbose -Verbose "$(PackageVersion)"
+      displayName: 'Write the package version'
+
     - template: assembly-module-compliance.yml@ComplianceRepo
       parameters:
         # binskim
@@ -153,6 +163,9 @@ stages:
         # tsa-upload
         codeBaseName: 'PowerShellNative'
         # selections
+        softwareName: 'PowerShellNative'
+        softwareNameFolder: '$(Pipeline.Workspace)/uncompressed'
+        softwareVersion: '$(PackageVersion)'
         APIScan: true # set to false when not using Windows APIs.
 
 - template: publish.yml

--- a/tools/releaseBuild/yaml/setVersion.yml
+++ b/tools/releaseBuild/yaml/setVersion.yml
@@ -1,0 +1,32 @@
+steps:
+- pwsh: |
+    $Branch = $env:BUILD_SOURCEBRANCH
+    $branchOnly = $Branch -replace '^refs/heads/';
+    $branchOnly = $branchOnly -replace '[_\-]'
+
+    Write-Verbose -Verbose "Branch == $Branch"
+    Write-Verbose -Verbose "BranchOnly == $branchOnly"
+
+    $packageVersion = if($env:PACKAGE_VERSION -eq 'fromBranch' -or !$env:PACKAGE_VERSION)
+    {
+      if($Branch -match '^.*(release[-/])')
+      {
+        Write-verbose "release branch:" -verbose
+        $Branch -replace '^.*(release[-/]v)'
+      }
+      else
+      {
+        Write-Verbose -Verbose "Branch is not a release branch. Defaulting to 99.99.99"
+        "99.99.99"
+      }
+    }
+    else {
+      Write-Verbose -Verbose "PACKAGE_VERSION is not equal to 'fromBranch'"
+      "99.99.99"
+    }
+
+    $vstsCommandString = "vso[task.setvariable variable=PackageVersion]$packageVersion"
+    Write-Verbose -Message "setting $Variable to $packageVersion" -Verbose
+    Write-Host -Object "##$vstsCommandString"
+
+  displayName: Set version variable


### PR DESCRIPTION
Added a new template to set the package version variable and provide APIScan task with the required parameters.