### PR TITLE
Use AllocConsole before initializing CLR to ensure codepage is correct

### DIFF
--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
@@ -37,6 +37,8 @@ unsigned int PowerShellCoreClrWorker::LaunchClr(
     _In_ LPCWSTR wszRuntimeVersion,
     _In_ LPCSTR friendlyName)
 {
+    // Allocate a console so that the codepage is setup correctly
+    AllocConsole();
     return commonLib->LaunchCoreCLR(hostWrapper, hostEnvironment, friendlyName);
 }
 


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/15128

Because PowerShell launched from pwrshplugin.dll via WinRM doesn't have a console attached, the console codepage is not setup correctly due to how .NET works.  This means that ANSI/Unicode characters are incorrectly represented.  Manually validated using `tree` command and this encoded command:

```console
PS> $cmd = {
>>     [Console]::Out.WriteLine('café')
>> }
PS> $encCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($cmd.ToString()))
PS> $s = New-PSSession . -ConfigurationName powershell.7
PS> Invoke-Command -Session $s { pwsh -encodedcommand $using:enccommand }
café
```
