### PR TITLE
Add CMAKE_CURRENT_BINARY_DIR to include path for generated header.

### DIFF
--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -41,4 +41,4 @@ configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/pal_config.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/pal_config.h)
 
-target_include_directories(psl-native PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(psl-native PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
when I try build it out of source tree, compilers complains that cannot found pal_config.h

```
citreu@asus-laptop:~/tmp/psl-native-build$ LANG=C make
Consolidate compiler generated dependencies of target psl-native
[  1%] Building CXX object src/CMakeFiles/psl-native.dir/getppid.cpp.o
/home/citreu/gitrepos/PowerShell-Native/src/libpsl-native/src/getppid.cpp:4:10: fatal error: pal_config.h: No such file or directory
    4 | #include "pal_config.h"
      |          ^~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [src/CMakeFiles/psl-native.dir/build.make:160: src/CMakeFiles/psl-native.dir/getppid.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:169: src/CMakeFiles/psl-native.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
citreu@asus-laptop:~/tmp/psl-native-build$ pwd
/home/citreu/tmp/psl-native-build
```

Adding `CMAKE_CURRENT_BINARY_DIR` to header include path should fix this issue.