### PR TITLE
Add new assembly `System.Security.Cryptography` to the trusted list

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -835,6 +835,7 @@ namespace NativeMsh
         "System.Security",
         "System.Security.AccessControl",
         "System.Security.Claims",
+        "System.Security.Cryptography",
         "System.Security.Cryptography.Algorithms",
         "System.Security.Cryptography.Cng",
         "System.Security.Cryptography.Csp",


### PR DESCRIPTION
The assembly is new in .NET 7 preview 1 and needs to be added to the trusted assemblies list for remoting to function properly.