### PR TITLE
Remove WSMan client libraries from the `Microsoft.PowerShell.Native` NuGet package

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -529,11 +529,7 @@ function Start-BuildPowerShellNativePackage
 
         [Parameter(Mandatory = $true)]
         [ValidateScript({Test-Path $_ -PathType Leaf})]
-        [string] $macOSZipPath,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateScript({Test-Path $_ -PathType Leaf})]
-        [string] $psrpZipPath
+        [string] $macOSZipPath
     )
 
     if(-not (Test-Path $PackageRoot))
@@ -554,7 +550,6 @@ function Start-BuildPowerShellNativePackage
     $BinFolderLinuxARM64 = Join-Path $tempExtractionPath "LinuxARM64"
     $BinFolderLinuxAlpine = Join-Path $tempExtractionPath "LinuxAlpine"
     $BinFolderMacOS = Join-Path $tempExtractionPath "MacOS"
-    $BinFolderPSRP = Join-Path $tempExtractionPath "PSRP"
 
     Expand-Archive -Path $WindowsX64ZipPath -DestinationPath $BinFolderX64 -Force
     Expand-Archive -Path $WindowsX86ZipPath -DestinationPath $BinFolderX86 -Force
@@ -565,11 +560,10 @@ function Start-BuildPowerShellNativePackage
     Expand-Archive -Path $LinuxARMZipPath -DestinationPath $BinFolderLinuxARM -Force
     Expand-Archive -Path $LinuxARM64ZipPath -DestinationPath $BinFolderLinuxARM64 -Force
     Expand-Archive -Path $macOSZipPath -DestinationPath $BinFolderMacOS -Force
-    Expand-Archive -Path $psrpZipPath -DestinationPath $BinFolderPSRP -Force
 
     PlaceWindowsNativeBinaries -PackageRoot $PackageRoot -BinFolderX64 $BinFolderX64 -BinFolderX86 $BinFolderX86 -BinFolderARM $BinFolderARM -BinFolderARM64 $BinFolderARM64
 
-    PlaceUnixBinaries -PackageRoot $PackageRoot -BinFolderLinux $BinFolderLinux -BinFolderLinuxARM $BinFolderLinuxARM -BinFolderLinuxARM64 $BinFolderLinuxARM64 -BinFolderOSX $BinFolderMacOS -BinFolderPSRP $BinFolderPSRP -BinFolderLinuxAlpine $BinFolderLinuxAlpine
+    PlaceUnixBinaries -PackageRoot $PackageRoot -BinFolderLinux $BinFolderLinux -BinFolderLinuxARM $BinFolderLinuxARM -BinFolderLinuxARM64 $BinFolderLinuxARM64 -BinFolderOSX $BinFolderMacOS -BinFolderLinuxAlpine $BinFolderLinuxAlpine
 
     $Nuspec = @'
 <?xml version="1.0" encoding="utf-8"?>
@@ -657,11 +651,7 @@ function PlaceUnixBinaries
 
         [Parameter(Mandatory = $true)]
         [ValidateScript({Test-Path $_ -PathType Container})]
-        $BinFolderOSX,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateScript({Test-Path $_ -PathType Container})]
-        $BinFolderPSRP
+        $BinFolderOSX
     )
 
     $RuntimePathLinux = New-Item -ItemType Directory -Path (Join-Path $PackageRoot -ChildPath 'runtimes/linux-x64/native') -Force
@@ -675,12 +665,6 @@ function PlaceUnixBinaries
     Copy-Item "$BinFolderLinuxARM64\*" -Destination $RuntimePathLinuxARM64 -Verbose
     Copy-Item "$BinFolderLinuxAlpine\*" -Destination $RuntimePathLinuxAlpine -Verbose
     Copy-Item "$BinFolderOSX\*" -Destination $RuntimePathOSX -Verbose
-
-    ## LinuxARM is not supported by PSRP
-    Get-ChildItem -Recurse $BinFolderPSRP/*.dylib | ForEach-Object { Copy-Item $_.FullName -Destination $RuntimePathOSX -Verbose }
-    Get-ChildItem -Recurse $BinFolderPSRP/*.so | ForEach-Object { Copy-Item $_.FullName -Destination $RuntimePathLinux -Verbose }
-
-    Copy-Item $BinFolderPSRP/version.txt -Destination "$PackageRoot/PSRP_version.txt" -Verbose
 }
 
 <#

--- a/tools/releaseBuild/yaml/nuget.yml
+++ b/tools/releaseBuild/yaml/nuget.yml
@@ -13,15 +13,6 @@ steps:
     targetPath: "$(System.ArtifactsDirectory)/signed"
   displayName: Download signed windows native packages
 
-- powershell: |
-    $null = New-Item $(PackageRoot) -ItemType Directory -Force -Verbose
-    if(-not (Test-Path '$(System.ArtifactsDirectory)/release' ))
-    {
-      New-Item -ItemType Directory -Path '$(System.ArtifactsDirectory)/release' -Force
-    }
-    Invoke-WebRequest -Uri '$(PSRPBlobUrl)' -OutFile $(System.ArtifactsDirectory)/release/psrp.zip -Verbose
-  displayName: 'Download PSRP package'
-
 - powershell: 'Get-ChildItem $(System.ArtifactsDirectory)/release'
   displayName: 'Capture downloaded zips'
 
@@ -80,9 +71,8 @@ steps:
    $LinuxARM64ZipPath = Join-Path "$(System.ArtifactsDirectory)/release" 'linux-arm64-symbols.zip'
    $LinuxAlpineZipPath = Join-Path "$(System.ArtifactsDirectory)/release" 'linux-musl-x64-symbols.zip'
    $macOSZipPath = Join-Path "$(System.ArtifactsDirectory)/release" 'osx-symbols.zip'
-   $psrpZipPath = Join-Path "$(System.ArtifactsDirectory)/release" 'psrp.zip'
 
-   Start-BuildPowerShellNativePackage -PackageRoot $PackageRoot -Version $(PackageVersion) -WindowsX64ZipPath  $WindowsX64ZipPath -WindowsX86ZipPath $WindowsX86ZipPath -WindowsARMZipPath $WindowsARMZipPath  -WindowsARM64ZipPath  $WindowsARM64ZipPath -LinuxZipPath $LinuxZipPath -LinuxARMZipPath  $LinuxARMZipPath -LinuxARM64ZipPath $LinuxARM64ZipPath -LinuxAlpineZipPath $LinuxAlpineZipPath -macOSZipPath $macOSZipPath -psrpZipPath $psrpZipPath
+   Start-BuildPowerShellNativePackage -PackageRoot $PackageRoot -Version $(PackageVersion) -WindowsX64ZipPath  $WindowsX64ZipPath -WindowsX86ZipPath $WindowsX86ZipPath -WindowsARMZipPath $WindowsARMZipPath  -WindowsARM64ZipPath  $WindowsARM64ZipPath -LinuxZipPath $LinuxZipPath -LinuxARMZipPath  $LinuxARMZipPath -LinuxARM64ZipPath $LinuxARM64ZipPath -LinuxAlpineZipPath $LinuxAlpineZipPath -macOSZipPath $macOSZipPath
 
   displayName: 'Collate NuGet package structure'
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

This is to address https://github.com/PowerShell/PowerShell/issues/17390

Remove WSMan client libraries from the `Microsoft.PowerShell.Native` NuGet package so that we stop shipping them with PowerShell packages.
