### PR TITLE
Hide the console for WinRM remoting

### DIFF
--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
@@ -39,6 +39,13 @@ unsigned int PowerShellCoreClrWorker::LaunchClr(
 {
     // Allocate a console so that the codepage is setup correctly
     AllocConsole();
+    HWND console = GetConsoleWindow();
+    if (console != NULL)
+    {
+        // Hide the console window
+        ShowWindow(console, SW_HIDE);
+    }
+
     return commonLib->LaunchCoreCLR(hostWrapper, hostEnvironment, friendlyName);
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The change to allocate a console so that the codepage is set correctly had the side effect of showing the console.  This change was deemed least risky to hide the console immediately.  Downside is there can be a flash of the console, but we can consider other fixes longer term with proper validation while this is needed to be backported to 7.3

## PR Context

Fix https://github.com/PowerShell/PowerShell-Native/issues/85
