### PR TITLE
FreeBSD include fix

### DIFF
--- a/src/libpsl-native/src/getuserfrompid.cpp
+++ b/src/libpsl-native/src/getuserfrompid.cpp
@@ -11,7 +11,7 @@
 #include <sstream>
 #include <errno.h>
 
-#if __APPLE__
+#if __APPLE__ || __FreeBSD__
 #include <sys/sysctl.h>
 #elif HAVE_SYSCONF
 // do nothing


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

FreeBSD has HAVE_SYSCONF defined, but you still need to include sysctl.h.

## PR Context

FreeBSD build was broken.