### PR TITLE
Use compiler flag -gdwarf-5 as per BinSkim

### DIFF
--- a/src/libpsl-native/CMakeLists.txt
+++ b/src/libpsl-native/CMakeLists.txt
@@ -3,7 +3,7 @@ project(PSL-NATIVE)
 
 # Can't use add_compile_options with 2.8.11
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -fstack-protector-strong -fpie -D_FORTIFY_SOURCE=2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -fstack-protector-strong -fpie -D_FORTIFY_SOURCE=2 -gdwarf-5")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR "FreeBSD")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro,-z,now")


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes a small change to the `src/libpsl-native/CMakeLists.txt` file. The change adds the `-gdwarf-5` flag to the `CMAKE_CXX_FLAGS` to enable DWARF version 5 debugging information.

* [`src/libpsl-native/CMakeLists.txt`](diffhunk://#diff-2fbbdfe3db5c8d1095bbe1115e7625b5b86500c53148cc2415812ba97ec280eaL6-R6): Added `-gdwarf-5` to the `CMAKE_CXX_FLAGS` for improved debugging information.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
