### PR TITLE
Don't request write permissions for RemotePowerShellConfig.txt

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/ConfigFileReader.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/ConfigFileReader.cpp
@@ -24,7 +24,7 @@ namespace NativeMsh
     {
         std::wstring absolutePathToConfigFile(pathToConfig);
         absolutePathToConfigFile += powerShellConfigFileName;
-        std::wfstream psConfigFile(absolutePathToConfigFile.c_str());
+        std::wifstream psConfigFile(absolutePathToConfigFile.c_str());
 
         if (!psConfigFile.is_open())
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Change remoting config file (`%windir%\System32\PowerShell\7.5.0\RemotePowerShellConfig.txt`) reader to use an input stream instead of an input/output stream. This means that write access is no longer needed in this system directory.
![image](https://github.com/user-attachments/assets/2288e81f-f85e-4eb8-9c03-db2bebd3096a)


<!-- Summarize your PR between here and the checklist. -->

## PR Context
This should help with issues:
https://github.com/MicrosoftDocs/PowerShell-Docs/issues/11682
https://github.com/PowerShell/PowerShell/issues/18741
https://github.com/PowerShell/PowerShell/issues/20180
https://github.com/PowerShell/PowerShell/issues/14274
https://github.com/PowerShell/PowerShell/issues/17367

## Tip
For completeness sake, I will mention that if you change `(Get-PSSessionConfiguration -Name <session_config_name>).Filename` to point at the dll that is present in PowerShell's install location (e.g. `"C:\Program Files\PowerShell\7\pwrshplugin.dll"`) it should work without write permissions, with the added benefit of always having this file auto-updated when a new version of PowerShell is installed.

Excellent write up in https://awakecoding.com/posts/enable-powershell-winrm-remoting-in-powershell-7/ shows the command to do that:
```
Set-Item -Path "WSMan:\localhost\Plugin\PowerShell.7\Filename" -Value $WSManPluginPath
```

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
