### PR TITLE
Replace DOTNET_SKIP_FIRST_TIME_EXPERIENCE with DOTNET_NOLOGO

### DIFF
--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -3,8 +3,7 @@ name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
-  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: 1
 
 resources:
   - repo: self

--- a/.vsts-ci/mac.yml
+++ b/.vsts-ci/mac.yml
@@ -3,8 +3,7 @@ name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
-  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: 1
 
 resources:
   - repo: self

--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -3,8 +3,7 @@ name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
-  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: 1
 
 resources:
   - repo: self


### PR DESCRIPTION
Suppress First Time Use Experience message in CI logs.

`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` was completely removed in .NET Core 3.0 and `DOTNET_NOLOGO` was reintroduced as its replacement in .NET Core 3.1 to only suppress the First Time Use Experience message.

cc: @daxian-dbw

See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo for details.
