### PR TITLE
Add support for linux-musl-arm64

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -99,6 +99,21 @@ extends:
           BuildPlatform: 'alpine'
           StageName: 'LinuxMuslBuild'
 
+    - stage: LinuxMuslArm64Build
+      displayName: Linux Musl ARM64 Build
+      variables:
+      - name: LinuxContainerImage
+        value: mcr.microsoft.com/dotnet/sdk:10.0-alpine
+
+      jobs:
+      - template: .pipelines/templates/build-docker.yml@self
+        parameters:
+          ARCHITECTURE: 'linux-musl-arm64'
+          Name: 'Linux_musl_arm64'
+          hostArchitecture: 'arm64'
+          BuildPlatform: 'alpine'
+          StageName: 'LinuxMuslArm64Build'
+
 
     - stage: LinuxRockyBuild
       displayName: Linux Rocky Build
@@ -142,7 +157,7 @@ extends:
           Name: 'Build_Linux_arm'
 
     - stage: Build_Nuget
-      dependsOn: [WinBuildAndSign, LinuxBuild, LinuxBuildARM, LinuxMuslBuild, LinuxRockyBuild]
+      dependsOn: [WinBuildAndSign, LinuxBuild, LinuxBuildARM, LinuxMuslBuild, LinuxMuslArm64Build, LinuxRockyBuild]
       displayName: Build NuGet
       jobs:
       - template: .pipelines/templates/build-nuget.yml@self

--- a/.pipelines/templates/build-nuget.yml
+++ b/.pipelines/templates/build-nuget.yml
@@ -35,6 +35,7 @@ jobs:
   - pwsh: |
       $platforms = @("drop_LinuxBuild_Build_Linux_arm64",
                      "drop_LinuxMuslBuild_ExtractLibPSL",
+                     "drop_LinuxMuslArm64Build_ExtractLibPSL",
                      "drop_LinuxRockyBuild_ExtractLibPSL",
                      "drop_LinuxBuildARM_Build_Linux_arm",
                      "drop_WinBuildAndSign_Build_Sign_x64",
@@ -50,6 +51,7 @@ jobs:
       $LinuxARMZipPath = "$(ob_outputDirectory)/drop_LinuxBuildARM_Build_Linux_arm.zip"
       $LinuxARM64ZipPath = "$(ob_outputDirectory)/drop_LinuxBuild_Build_Linux_arm64.zip"
       $LinuxAlpineZipPath = "$(ob_outputDirectory)/drop_LinuxMuslBuild_ExtractLibPSL.zip"
+      $LinuxAlpineARM64ZipPath = "$(ob_outputDirectory)/drop_LinuxMuslArm64Build_ExtractLibPSL.zip"
       $LinuxRockyZipPath = "$(ob_outputDirectory)/drop_LinuxRockyBuild_ExtractLibPSL.zip"
       $macOSZipPath = "$(ob_outputDirectory)/drop_osx.zip"
 
@@ -72,7 +74,7 @@ jobs:
 
       Import-Module $(Build.SourcesDirectory)/build.psm1 -Force
       $PackageRoot = New-Item -ItemType Directory -Path  $(ob_outputDirectory)\NugetPackageSrc
-      Start-BuildPowerShellNativePackage -PackageRoot $PackageRoot -Version $(PackageVersion) -WindowsX64ZipPath  $WindowsX64ZipPath -WindowsX86ZipPath $WindowsX86ZipPath -WindowsARM64ZipPath  $WindowsARM64ZipPath -LinuxZipPath $LinuxRockyZipPath -LinuxARMZipPath  $LinuxARMZipPath -LinuxARM64ZipPath $LinuxARM64ZipPath -LinuxAlpineZipPath $LinuxAlpineZipPath -macOSZipPath $macOSZipPath
+      Start-BuildPowerShellNativePackage -PackageRoot $PackageRoot -Version $(PackageVersion) -WindowsX64ZipPath  $WindowsX64ZipPath -WindowsX86ZipPath $WindowsX86ZipPath -WindowsARM64ZipPath  $WindowsARM64ZipPath -LinuxZipPath $LinuxRockyZipPath -LinuxARMZipPath  $LinuxARMZipPath -LinuxARM64ZipPath $LinuxARM64ZipPath -LinuxAlpineZipPath $LinuxAlpineZipPath -LinuxAlpineARM64ZipPath $LinuxAlpineARM64ZipPath -macOSZipPath $macOSZipPath
 
       Write-Verbose -Verbose "Enumerating $symbolsRoot"
       Get-ChildItem -Path $symbolsRoot -Recurse

--- a/build.psm1
+++ b/build.psm1
@@ -592,6 +592,10 @@ function Start-BuildPowerShellNativePackage
 
         [Parameter(Mandatory = $true)]
         [ValidateScript({Test-Path $_ -PathType Leaf})]
+        [string] $LinuxAlpineARM64ZipPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({Test-Path $_ -PathType Leaf})]
         [string] $macOSZipPath
     )
 
@@ -611,6 +615,7 @@ function Start-BuildPowerShellNativePackage
     $BinFolderLinuxARM = Join-Path $tempExtractionPath "LinuxARM"
     $BinFolderLinuxARM64 = Join-Path $tempExtractionPath "LinuxARM64"
     $BinFolderLinuxAlpine = Join-Path $tempExtractionPath "LinuxAlpine"
+    $BinFolderLinuxAlpineARM64 = Join-Path $tempExtractionPath "LinuxAlpineARM64"
     $BinFolderMacOS = Join-Path $tempExtractionPath "MacOS"
 
     Expand-Archive -Path $WindowsX64ZipPath -DestinationPath $BinFolderX64 -Force
@@ -618,13 +623,14 @@ function Start-BuildPowerShellNativePackage
     Expand-Archive -Path $WindowsARM64ZipPath -DestinationPath $BinFolderARM64 -Force
     Expand-Archive -Path $LinuxZipPath -DestinationPath $BinFolderLinux -Force
     Expand-Archive -Path $LinuxAlpineZipPath -DestinationPath $BinFolderLinuxAlpine -Force
+    Expand-Archive -Path $LinuxAlpineARM64ZipPath -DestinationPath $BinFolderLinuxAlpineARM64 -Force
     Expand-Archive -Path $LinuxARMZipPath -DestinationPath $BinFolderLinuxARM -Force
     Expand-Archive -Path $LinuxARM64ZipPath -DestinationPath $BinFolderLinuxARM64 -Force
     Expand-Archive -Path $macOSZipPath -DestinationPath $BinFolderMacOS -Force
 
     PlaceWindowsNativeBinaries -PackageRoot $PackageRoot -BinFolderX64 $BinFolderX64 -BinFolderX86 $BinFolderX86 -BinFolderARM64 $BinFolderARM64
 
-    PlaceUnixBinaries -PackageRoot $PackageRoot -BinFolderLinux $BinFolderLinux -BinFolderLinuxARM $BinFolderLinuxARM -BinFolderLinuxARM64 $BinFolderLinuxARM64 -BinFolderOSX $BinFolderMacOS -BinFolderLinuxAlpine $BinFolderLinuxAlpine
+    PlaceUnixBinaries -PackageRoot $PackageRoot -BinFolderLinux $BinFolderLinux -BinFolderLinuxARM $BinFolderLinuxARM -BinFolderLinuxARM64 $BinFolderLinuxARM64 -BinFolderOSX $BinFolderMacOS -BinFolderLinuxAlpine $BinFolderLinuxAlpine -BinFolderLinuxAlpineARM64 $BinFolderLinuxAlpineARM64
 
     $Nuspec = @'
 <?xml version="1.0" encoding="utf-8"?>
@@ -712,6 +718,10 @@ function PlaceUnixBinaries
 
         [Parameter(Mandatory = $true)]
         [ValidateScript({Test-Path $_ -PathType Container})]
+        $BinFolderLinuxAlpineARM64,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({Test-Path $_ -PathType Container})]
         $BinFolderOSX
     )
 
@@ -719,12 +729,14 @@ function PlaceUnixBinaries
     $RuntimePathLinuxARM = New-Item -ItemType Directory -Path (Join-Path $PackageRoot -ChildPath 'runtimes/linux-arm/native') -Force
     $RuntimePathLinuxARM64 = New-Item -ItemType Directory -Path (Join-Path $PackageRoot -ChildPath 'runtimes/linux-arm64/native') -Force
     $RuntimePathLinuxAlpine = New-Item -ItemType Directory -Path (Join-Path $PackageRoot -ChildPath 'runtimes/linux-musl-x64/native') -Force
+    $RuntimePathLinuxAlpineARM64 = New-Item -ItemType Directory -Path (Join-Path $PackageRoot -ChildPath 'runtimes/linux-musl-arm64/native') -Force
     $RuntimePathOSX = New-Item -ItemType Directory -Path (Join-Path $PackageRoot -ChildPath 'runtimes/osx/native') -Force
 
     Copy-Item "$BinFolderLinux\*" -Destination $RuntimePathLinux -Verbose
     Copy-Item "$BinFolderLinuxARM\*" -Destination $RuntimePathLinuxARM -Verbose
     Copy-Item "$BinFolderLinuxARM64\*" -Destination $RuntimePathLinuxARM64 -Verbose
     Copy-Item "$BinFolderLinuxAlpine\*" -Destination $RuntimePathLinuxAlpine -Verbose
+    Copy-Item "$BinFolderLinuxAlpineARM64\*" -Destination $RuntimePathLinuxAlpineARM64 -Verbose
     Copy-Item "$BinFolderOSX\*" -Destination $RuntimePathOSX -Verbose
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add support for `linux-musl-arm64`.

To unblock https://github.com/PowerShell/PowerShell/issues/25762 we first need to add support for `linux-musl-arm64` in PowerShell-Native, then we'll be able to update the PowerShell repository.

In my understanding, The `build-docker.yml` template in PowerShell-Native already has a conditional for `linux-musl-arm64` (line 70). So this was partially anticipated, the remaining work seems to be wiring it through.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

1. CI pipeline — Add a LinuxMuslArm64Build stage in release.yml that builds libpsl-native.so inside an Alpine ARM64 Docker container (same approach as existing Alpine x64 build)
2. NuGet packaging — Add runtimes/linux-musl-arm64/native to the NuGet package layout in build.psm1
3. NuGet build pipeline — Wire the new artifact into build-nuget.yml
