### PR TITLE
Add NetFramingBase to TPA for AD module compat

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -856,6 +856,7 @@ namespace NativeMsh
         "System.ServiceModel",
         "System.ServiceModel.Duplex",
         "System.ServiceModel.Http",
+        "System.ServiceModel.NetFramingBase",
         "System.ServiceModel.NetTcp",
         "System.ServiceModel.Primitives",
         "System.ServiceModel.Security",


### PR DESCRIPTION
Adds System.ServiceModel.NetFramingBase to the list of Trusted Platform Assemblies so that a PSSession instance can load that assembly by name. The ActiveDirectory module uses this assembly and without this change it will fail to import into a PowerShell 7 configuration endpoint.

FIxes: https://github.com/PowerShell/PowerShell/issues/27199